### PR TITLE
Feat/dashboard auth context

### DIFF
--- a/apps/hindsight-dashboard/src/App.jsx
+++ b/apps/hindsight-dashboard/src/App.jsx
@@ -18,44 +18,16 @@ import PruningSuggestions from './components/PruningSuggestions';
 import MemoryOptimizationCenter from './components/MemoryOptimizationCenter';
 import AboutModal from './components/AboutModal';
 import NotificationContainer from './components/NotificationContainer';
-
-// Services
-import authService from './api/authService';
+import { AuthProvider } from './context/AuthContext';
 
 function AppContent() {
   const location = useLocation();
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [showAboutModal, setShowAboutModal] = useState(false);
 
   useEffect(() => {
-    fetchUserInfo();
     // Set document title
     document.title = 'Hindsight-AI';
   }, []);
-
-  const fetchUserInfo = async () => {
-    try {
-      const userInfo = await authService.getCurrentUser();
-      setUser(userInfo);
-    } catch (error) {
-      console.error('Error fetching user info:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Loading state
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading...</p>
-        </div>
-      </div>
-    );
-  }
 
   // Authentication check (commented out as in original)
   // if (!user || !user.authenticated) {
@@ -126,7 +98,9 @@ function AppContent() {
 function App() {
   return (
     <Router>
-      <AppContent />
+      <AuthProvider>
+        <AppContent />
+      </AuthProvider>
     </Router>
   );
 }

--- a/apps/hindsight-dashboard/src/components/MainContent.jsx
+++ b/apps/hindsight-dashboard/src/components/MainContent.jsx
@@ -18,11 +18,7 @@ const MainContent = ({ children, title, sidebarCollapsed }) => {
           </p>
         </div>
         <div>
-          <button className="p-2 rounded-full hover:bg-gray-200 transition duration-200">
-            <svg className="w-6 h-6 text-gray-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
-          </button>
+          <UserAccountButton />
         </div>
       </header>
 

--- a/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
+++ b/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
@@ -36,9 +36,6 @@ const UserAccountButton = () => {
         <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold">
           {user.email ? user.email.charAt(0).toUpperCase() : 'U'}
         </div>
-        <span className="text-sm text-gray-700 hidden md:block">
-          {user.email || user.user}
-        </span>
         <svg
           className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${showDropdown ? 'rotate-180' : ''}`}
           fill="none"

--- a/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
+++ b/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
@@ -1,25 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import authService from '../api/authService';
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
 
 const UserAccountButton = () => {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const { user, loading } = useAuth();
   const [showDropdown, setShowDropdown] = useState(false);
-
-  useEffect(() => {
-    fetchUserInfo();
-  }, []);
-
-  const fetchUserInfo = async () => {
-    try {
-      const userInfo = await authService.getCurrentUser();
-      setUser(userInfo);
-    } catch (error) {
-      console.error('Error fetching user info:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleLogout = () => {
     // Redirect to logout URL or handle logout logic

--- a/apps/hindsight-dashboard/src/context/AuthContext.jsx
+++ b/apps/hindsight-dashboard/src/context/AuthContext.jsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import authService from '../api/authService';
+
+const AuthContext = createContext({
+  user: null,
+  loading: true,
+  refresh: async () => {},
+});
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = async () => {
+    try {
+      const info = await authService.getCurrentUser();
+      setUser(info);
+    } catch (err) {
+      // In dev, unauthenticated is acceptable; keep user null
+      console.error('Auth refresh error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // Optionally revalidate when tab becomes visible again
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, []);
+
+  const value = useMemo(() => ({ user, loading, refresh }), [user, loading]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+


### PR DESCRIPTION
This pull request refactors the authentication logic in the Hindsight Dashboard app to use a centralized React context (`AuthContext`) for user authentication state. The main improvements include removing duplicate user-fetching logic, simplifying component code, and providing a consistent way to access authentication state throughout the app.

**Authentication Context Integration:**

* Added `AuthContext` and `AuthProvider` in `apps/hindsight-dashboard/src/context/AuthContext.jsx`, which centralizes user authentication state, loading state, and refresh logic. Components can now access authentication data via the `useAuth` hook.

* Updated `apps/hindsight-dashboard/src/App.jsx` to wrap the main app content in `AuthProvider`, removing local user-fetching and loading logic from `AppContent`. This ensures all components have access to the authentication context. [[1]](diffhunk://#diff-12ec8018695b57bebf11da7ba0098086748f6743c2dcb689f03e225eb753eea7L21-L59) [[2]](diffhunk://#diff-12ec8018695b57bebf11da7ba0098086748f6743c2dcb689f03e225eb753eea7R101-R103)

**Component Simplification and Consistency:**

* Refactored `UserAccountButton` in `apps/hindsight-dashboard/src/components/UserAccountButton.jsx` to use the `useAuth` hook for user and loading state, removing its own fetch logic and dependency on `authService`.

* Replaced the generic user icon button in `apps/hindsight-dashboard/src/components/MainContent.jsx` with the new `UserAccountButton` component, ensuring consistent user account display and interaction.

**UI Adjustments:**

* Simplified the user account display in `UserAccountButton` by removing the user's email display from the header (now only the initial is shown in the avatar).