### PR TITLE
Traefik: add auth-errors middleware to redirect 401 to oauth2-proxy s…

### DIFF
--- a/config/dynamic.yml
+++ b/config/dynamic.yml
@@ -2,6 +2,12 @@
 
 http:
   middlewares:
+    auth-errors:
+      errors:
+        status:
+          - "401"
+        service: oauth2-svc@docker
+        query: "/oauth2/sign_in?rd=https://app.hindsight-ai.com/"
     secure-headers:
       headers:
         forceSTSHeader: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,7 +78,7 @@ services:
       - "traefik.http.routers.oauth2-proxy.rule=(Host(`auth.hindsight-ai.com`)) && PathPrefix(`/oauth2`)"
       - "traefik.http.routers.oauth2-proxy.entrypoints=websecure"
       - "traefik.http.routers.oauth2-proxy.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.oauth2-proxy-router.service=oauth2-svc@docker"
+      - "traefik.http.routers.oauth2-proxy.service=oauth2-svc@docker"
       - "traefik.http.services.oauth2-svc.loadbalancer.server.port=4180"
 
   hindsight-service:
@@ -114,9 +114,23 @@ services:
       - "traefik.http.routers.hindsight-dashboard-router.rule=Host(`app.hindsight-ai.com`) && PathPrefix(`/`)"
       - "traefik.http.routers.hindsight-dashboard-router.entrypoints=websecure"
       - "traefik.http.routers.hindsight-dashboard-router.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.hindsight-dashboard-router.middlewares=cors-headers@file,oauth-middleware@file"
+      - "traefik.http.routers.hindsight-dashboard-router.middlewares=secure-headers@file,oauth-middleware@file,auth-errors@file"
       - "traefik.http.routers.hindsight-dashboard-router.service=hindsight-dashboard-svc@docker"
       - "traefik.http.services.hindsight-dashboard-svc.loadbalancer.server.port=80"
+      # Public router for manifest.json to prevent 401 during browser prefetch
+      - "traefik.http.routers.hindsight-dashboard-manifest.rule=Host(`app.hindsight-ai.com`) && Path(`/manifest.json`)"
+      - "traefik.http.routers.hindsight-dashboard-manifest.entrypoints=websecure"
+      - "traefik.http.routers.hindsight-dashboard-manifest.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.hindsight-dashboard-manifest.service=hindsight-dashboard-svc@docker"
+      - "traefik.http.routers.hindsight-dashboard-manifest.middlewares=secure-headers@file"
+      - "traefik.http.routers.hindsight-dashboard-manifest.priority=1000"
+      # Also allow favicon without auth to prevent browser noise
+      - "traefik.http.routers.hindsight-dashboard-favicon.rule=Host(`app.hindsight-ai.com`) && Path(`/favicon.ico`)"
+      - "traefik.http.routers.hindsight-dashboard-favicon.entrypoints=websecure"
+      - "traefik.http.routers.hindsight-dashboard-favicon.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.hindsight-dashboard-favicon.service=hindsight-dashboard-svc@docker"
+      - "traefik.http.routers.hindsight-dashboard-favicon.middlewares=secure-headers@file"
+      - "traefik.http.routers.hindsight-dashboard-favicon.priority=1000"
 
 networks:
   hindsight-ai:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - "traefik.http.routers.oauth2-proxy.rule=(Host(`auth.hindsight-ai.com`)) && PathPrefix(`/oauth2`)"
       - "traefik.http.routers.oauth2-proxy.entrypoints=websecure"
       - "traefik.http.routers.oauth2-proxy.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.oauth2-proxy-router.service=oauth2-svc@docker"
+      - "traefik.http.routers.oauth2-proxy.service=oauth2-svc@docker"
       - "traefik.http.services.oauth2-svc.loadbalancer.server.port=4180"
 
   hindsight-service:
@@ -117,7 +117,7 @@ services:
       - "traefik.http.routers.hindsight-dashboard-router.entrypoints=websecure"
       - "traefik.http.routers.hindsight-dashboard-router.tls.certresolver=letsencrypt"
       # Protect the dashboard with OAuth2 forward auth
-      - "traefik.http.routers.hindsight-dashboard-router.middlewares=secure-headers@file,oauth-middleware@file"
+      - "traefik.http.routers.hindsight-dashboard-router.middlewares=secure-headers@file,oauth-middleware@file,auth-errors@file"
       - "traefik.http.routers.hindsight-dashboard-router.service=hindsight-dashboard-svc@docker"
       - "traefik.http.services.hindsight-dashboard-svc.loadbalancer.server.port=80"
       # Public router for manifest.json to prevent 401 during browser prefetch


### PR DESCRIPTION
This pull request updates the authentication and routing configuration for the Hindsight dashboard and OAuth2 proxy, improving error handling and public asset access. The main changes include adding a middleware for handling authentication errors, refining router and service labels, and explicitly allowing unauthenticated access to certain static assets to prevent browser issues.

**Authentication and error handling improvements:**

* Added a new `auth-errors` middleware in `config/dynamic.yml` to handle `401` errors by redirecting unauthenticated users to the OAuth2 sign-in page.
* Updated the dashboard router middlewares in both `docker-compose.yml` and `docker-compose.prod.yml` to include `auth-errors@file`, ensuring consistent handling of authentication errors across environments. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L120-R120) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L117-R133)

**Router and service configuration fixes:**

* Corrected the service label for the OAuth2 proxy router from `oauth2-proxy-router.service` to `oauth2-proxy.service` in both compose files, ensuring proper routing to the OAuth2 service. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L81-R81) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L81-R81)

**Public asset access enhancements:**

* Added public routers for `manifest.json` and `favicon.ico` in `docker-compose.prod.yml`, allowing these assets to be served without authentication and preventing browser errors during prefetch and favicon requests.…ign-in; fix oauth2-proxy router service label; allow public manifest/favicon; attach middleware to dashboard routers