### PR TITLE
Feat/auth redirect

### DIFF
--- a/apps/hindsight-dashboard/src/App.jsx
+++ b/apps/hindsight-dashboard/src/App.jsx
@@ -29,27 +29,6 @@ function AppContent() {
     document.title = 'Hindsight-AI';
   }, []);
 
-  // Authentication check (commented out as in original)
-  // if (!user || !user.authenticated) {
-  //   return (
-  //     <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-  //       <div className="text-center">
-  //         <h1 className="text-2xl font-bold text-gray-800 mb-4">AI Agent Memory Dashboard</h1>
-  //         <div className="bg-white p-8 rounded-lg shadow-md max-w-md">
-  //           <h2 className="text-xl font-semibold mb-4">Authentication Required</h2>
-  //           <p className="text-gray-600 mb-6">Please sign in to access the AI Agent Memory Dashboard.</p>
-  //           <button
-  //             className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg transition duration-200"
-  //             onClick={() => window.location.href = 'https://auth.hindsight-ai.com/oauth2/sign_in?rd=https%3A%2F%2Fapp.hindsight-ai.com'}
-  //           >
-  //             Sign In
-  //           </button>
-  //         </div>
-  //       </div>
-  //     </div>
-  //   );
-  // }
-
   // Get page title based on current route
   const getPageTitle = (pathname) => {
     const routeMap = {

--- a/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
+++ b/apps/hindsight-dashboard/src/components/UserAccountButton.jsx
@@ -7,7 +7,8 @@ const UserAccountButton = () => {
 
   const handleLogout = () => {
     // Redirect to logout URL or handle logout logic
-    window.location.href = 'https://auth.hindsight-ai.com/oauth2/sign_out?rd=https%3A%2F%2Fapp.hindsight-ai.com';
+    const rd = encodeURIComponent(window.location.origin);
+    window.location.href = `/oauth2/sign_out?rd=${rd}`;
   };
 
   if (loading) {
@@ -19,7 +20,10 @@ const UserAccountButton = () => {
   if (!user || !user.authenticated) {
     return (
       <button
-        onClick={() => window.location.href = 'https://auth.hindsight-ai.com/oauth2/sign_in?rd=https%3A%2F%2Fapp.hindsight-ai.com'}
+        onClick={() => {
+          const rd = encodeURIComponent(window.location.pathname + window.location.search + window.location.hash);
+          window.location.href = `/oauth2/sign_in?rd=${rd}`;
+        }}
         className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition duration-200"
       >
         Sign In

--- a/apps/hindsight-dashboard/src/services/notificationService.js
+++ b/apps/hindsight-dashboard/src/services/notificationService.js
@@ -96,7 +96,8 @@ class NotificationService {
       message: 'Authentication error (401). Your session may have expired. Please refresh authentication to continue.',
       duration: 30000,
       onRefresh: () => {
-        window.location.href = 'https://auth.hindsight-ai.com/oauth2/sign_in?rd=https%3A%2F%2Fapp.hindsight-ai.com';
+        const rd = encodeURIComponent(window.location.pathname + window.location.search + window.location.hash);
+        window.location.href = `/oauth2/sign_in?rd=${rd}`;
       }
     });
   }

--- a/config/dynamic.yml
+++ b/config/dynamic.yml
@@ -7,7 +7,7 @@ http:
         status:
           - "401"
         service: oauth2-svc@docker
-        query: "/oauth2/sign_in?rd=https://app.hindsight-ai.com/"
+        query: "/oauth2/sign_in?rd=/"
     secure-headers:
       headers:
         forceSTSHeader: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,14 +49,14 @@ services:
     environment:
       OAUTH2_PROXY_PROVIDER: google
       OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
-      OAUTH2_PROXY_REDIRECT_URL: https://auth.hindsight-ai.com/oauth2/callback
+      OAUTH2_PROXY_REDIRECT_URL: https://app.hindsight-ai.com/oauth2/callback
       OAUTH2_PROXY_UPSTREAMS: http://hindsight-dashboard:80
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: true
       OAUTH2_PROXY_COOKIE_SAMESITE: none
       OAUTH2_PROXY_COOKIE_SECURE: true
       OAUTH2_PROXY_COOKIE_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_CSRF_COOKIE_DOMAINS: .hindsight-ai.com
-      OAUTH2_PROXY_WHITELIST_DOMAINS: .hindsight-ai.com,.google.com
+      OAUTH2_PROXY_WHITELIST_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_REVERSE_PROXY: true
       OAUTH2_PROXY_SET_XAUTHREQUEST: true
       OAUTH2_PROXY_PASS_ACCESS_TOKEN: true
@@ -76,7 +76,6 @@ services:
       - ./templates:/templates:ro
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.oauth2-proxy.rule=(Host(`auth.hindsight-ai.com`)) && PathPrefix(`/oauth2`)"
       - "traefik.http.routers.oauth2-proxy.entrypoints=websecure"
       - "traefik.http.routers.oauth2-proxy.tls.certresolver=letsencrypt"
       - "traefik.http.routers.oauth2-proxy.service=oauth2-svc@docker"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     environment:
       OAUTH2_PROXY_PROVIDER: google
       OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
-      OAUTH2_PROXY_REDIRECT_URL: https://auth.hindsight-ai.com/oauth2/callback
+      OAUTH2_PROXY_REDIRECT_URL: https://app.hindsight-ai.com/oauth2/callback
       # Reverse-proxy mode: send authenticated traffic to the dashboard service
       OAUTH2_PROXY_UPSTREAMS: http://hindsight-dashboard:80
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: true
@@ -57,7 +57,7 @@ services:
       OAUTH2_PROXY_COOKIE_SECURE: true
       OAUTH2_PROXY_COOKIE_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_CSRF_COOKIE_DOMAINS: .hindsight-ai.com
-      OAUTH2_PROXY_WHITELIST_DOMAINS: .hindsight-ai.com,.google.com
+      OAUTH2_PROXY_WHITELIST_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_REVERSE_PROXY: true
       OAUTH2_PROXY_SET_XAUTHREQUEST: true
       OAUTH2_PROXY_PASS_ACCESS_TOKEN: true
@@ -78,7 +78,6 @@ services:
       - ./templates:/templates:ro
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.oauth2-proxy.rule=(Host(`auth.hindsight-ai.com`)) && PathPrefix(`/oauth2`)"
       - "traefik.http.routers.oauth2-proxy.entrypoints=websecure"
       - "traefik.http.routers.oauth2-proxy.tls.certresolver=letsencrypt"
       - "traefik.http.routers.oauth2-proxy.service=oauth2-svc@docker"

--- a/templates/error.html
+++ b/templates/error.html
@@ -27,7 +27,7 @@
             <p><strong>Admin Contact:</strong> <a href="mailto:ibarz.jean@gmail.com">ibarz.jean@gmail.com</a></p>
             <div class="field is-grouped buttons">
                 <a class="button is-danger" href="javascript:history.back()">Go back</a>
-                <a class="button is-success" href="/oauth2/sign_out">Sign Out</a>
+                <a class="button is-success" href="/oauth2/sign_out?rd=/">Sign Out</a>
             </div>
             <div class="dropdown is-hoverable">
                 <div class="dropdown-trigger">


### PR DESCRIPTION
This pull request refactors authentication and OAuth2 proxy handling to improve redirect logic and simplify domain usage. The changes focus on updating redirect URLs to consistently use relative paths, removing hardcoded domains, and tightening the OAuth2 proxy configuration for security and maintainability.

**Authentication redirect logic:**

* Updated sign-in and sign-out redirects in `UserAccountButton.jsx` and `notificationService.js` to use relative paths (`/oauth2/sign_in` and `/oauth2/sign_out`) and dynamically encode the current location for the `rd` (redirect) parameter, replacing hardcoded URLs. [[1]](diffhunk://#diff-6c07c6a298aa7702b5f8a48ebc97ad62bf729939cafa8bcbe1400259e9cfb7ddL10-R11) [[2]](diffhunk://#diff-6c07c6a298aa7702b5f8a48ebc97ad62bf729939cafa8bcbe1400259e9cfb7ddL22-R26) [[3]](diffhunk://#diff-9732050ebeebac7d2dc8be2277e5debca73fa54b9e7fbcd557a4e69736f85a8cL99-R100)
* Updated the error page template (`error.html`) to use a relative sign-out URL with a root redirect (`rd=/`).

**OAuth2 proxy and configuration updates:**

* Changed OAuth2 proxy redirect URLs in both `docker-compose.yml` and `docker-compose.prod.yml` to use `https://app.hindsight-ai.com/oauth2/callback` instead of the previous `auth.hindsight-ai.com` domain, and removed `.google.com` from the whitelist domains for tighter security. [[1]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L52-R59) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L79) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L52-R60) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L81)
* Updated the dynamic configuration (`dynamic.yml`) to use a relative path for the sign-in query and root redirect.

**Code cleanup:**

* Removed commented-out authentication check logic from `App.jsx` that was no longer in use.