### PR TITLE
security: reduce CSRF risk by setting oauth2-proxy cookies SameSite=l…

### DIFF
--- a/apps/hindsight-dashboard/nginx.conf
+++ b/apps/hindsight-dashboard/nginx.conf
@@ -17,6 +17,19 @@ server {
     proxy_set_header X-Auth-Request-Email $http_x_auth_request_email;
     proxy_set_header X-Auth-Request-Access-Token $http_x_auth_request_access_token;
     proxy_set_header Authorization $http_authorization;
+
+    # CSRF mitigation: for mutating methods, only allow allowed origins
+    set $is_modifying 0;
+    if ($request_method ~* "^(POST|PUT|PATCH|DELETE)$") { set $is_modifying 1; }
+    set $origin_allowed 0;
+    if ($http_origin = "https://app.hindsight-ai.com") { set $origin_allowed 1; }
+    if ($http_origin = "http://localhost:3000") { set $origin_allowed 1; }
+    if ($http_origin = "http://localhost") { set $origin_allowed 1; }
+    if ($is_modifying = 1) {
+      if ($http_origin != "") {
+        if ($origin_allowed = 0) { return 403; }
+      }
+    }
     proxy_redirect off;
     proxy_read_timeout 300s;
   }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
       OAUTH2_PROXY_REDIRECT_URL: https://app.hindsight-ai.com/oauth2/callback
       OAUTH2_PROXY_UPSTREAMS: http://hindsight-dashboard:80
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: true
-      OAUTH2_PROXY_COOKIE_SAMESITE: none
+      OAUTH2_PROXY_COOKIE_SAMESITE: lax
       OAUTH2_PROXY_COOKIE_SECURE: true
       OAUTH2_PROXY_COOKIE_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_CSRF_COOKIE_DOMAINS: .hindsight-ai.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       # Reverse-proxy mode: send authenticated traffic to the dashboard service
       OAUTH2_PROXY_UPSTREAMS: http://hindsight-dashboard:80
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: true
-      OAUTH2_PROXY_COOKIE_SAMESITE: none
+      OAUTH2_PROXY_COOKIE_SAMESITE: lax
       OAUTH2_PROXY_COOKIE_SECURE: true
       OAUTH2_PROXY_COOKIE_DOMAINS: .hindsight-ai.com
       OAUTH2_PROXY_CSRF_COOKIE_DOMAINS: .hindsight-ai.com


### PR DESCRIPTION
This pull request introduces important security improvements to the authentication and proxy configuration for the dashboard application. The main changes focus on mitigating CSRF risks by restricting allowed origins for mutating HTTP methods and strengthening cookie handling policies.

**CSRF Mitigation and Origin Restrictions**
* Updated `apps/hindsight-dashboard/nginx.conf` to block mutating requests (POST, PUT, PATCH, DELETE) from unapproved origins, returning a 403 error if the request's origin is not explicitly allowed. Approved origins are `https://app.hindsight-ai.com`, `http://localhost:3000`, and `http://localhost`.

**Cookie Policy Improvements**
* Changed `OAUTH2_PROXY_COOKIE_SAMESITE` from `none` to `lax` in both `docker-compose.prod.yml` and `docker-compose.yml`, reducing the risk of cross-site request forgery by limiting cookie transmission to same-site requests or top-level navigation. [[1]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L55-R55) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L56-R56)