### PR TITLE
docs: update embedding backfill instructions

### DIFF
--- a/apps/hindsight-service/README.md
+++ b/apps/hindsight-service/README.md
@@ -84,11 +84,20 @@ Local Docker Compose profiles spin up `ollama/ollama` alongside Postgres and the
 
 Run the utility script once a provider is configured:
 
-```bash
-uv run python scripts/backfill_embeddings.py --batch-size 200
-```
+- **Staging/production servers:**
 
-Add `--dry-run` to inspect how many rows still need embeddings before running the job.
+  ```bash
+  docker compose -f docker-compose.app.yml exec -w /app hindsight-service \
+    env PYTHONPATH=/app python scripts/backfill_embeddings.py --batch-size 200
+  ```
+
+- **Local development:**
+
+  ```bash
+  uv run python scripts/backfill_embeddings.py --batch-size 200
+  ```
+
+Add `--dry-run` in either environment to inspect how many rows still need embeddings before running the job.
 
 ### Hybrid Ranking Configuration
 

--- a/docs/search-retrieval-overview.md
+++ b/docs/search-retrieval-overview.md
@@ -14,7 +14,7 @@ Operational notes:
 
 - Generate embeddings synchronously on memory create/update when a provider is enabled.
 - Keep the mock provider as default in CI; monitor latency/cost for real providers.
-- After enabling a real provider, run the backfill script to hydrate historical memories.
+- After enabling a real provider, run the backfill script to hydrate historical memories. On deployed servers run `docker compose -f docker-compose.app.yml exec -w /app hindsight-service env PYTHONPATH=/app python scripts/backfill_embeddings.py --batch-size 200` (add `--dry-run` first if you only want a count).
 
 ## Hybrid Ranking
 


### PR DESCRIPTION
This pull request updates the documentation to clarify how to run the embedding backfill script in different environments, specifically distinguishing between local development and staging/production servers. It provides explicit commands for each environment and emphasizes the use of the `--dry-run` flag for safer operation.

Documentation improvements for embedding backfill:

* Added step-by-step instructions for running the `backfill_embeddings.py` script on staging/production servers using Docker Compose, including the appropriate command syntax. [[1]](diffhunk://#diff-cbf778f5cf0fe3c9070684dfb96288c701a3f8421546d96b10c43f0934f4de81R87-R100) [[2]](diffhunk://#diff-7e66eee4bbf3447ad36ec471af434d3b20de49617d78f11e6354290862143811L17-R17)
* Clarified that the `--dry-run` flag can be used in any environment to preview the number of rows needing embeddings before executing the job.
* Updated operational notes to specify the correct command for running the backfill script on deployed servers, and recommended adding `--dry-run` for a count-only operation.