### PR TITLE
refactor: update conversation ID handling and improve documentation i…

### DIFF
--- a/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
+++ b/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
@@ -54,7 +54,7 @@ interface WorkflowGroup {
 
 const codexConfigSnippet = `[mcp_servers.hindsight-mcp]
 command = "hindsight-mcp"
-env = { "HINDSIGHT_API_TOKEN" = "<yourtoken>", "DEFAULT_AGENT_ID" = "<youragentid>", "DEFAULT_CONVERSATION_ID" = "f47ac10b-58cc-4372-a567-0123456789ab" }`;
+env = { "HINDSIGHT_API_TOKEN" = "<yourtoken>", "DEFAULT_AGENT_ID" = "<youragentid>" }`;
 
 const workflowExample = `# Workflow Guidance
 
@@ -70,8 +70,7 @@ const geminiConfigSnippet = `{
       "command": "hindsight-mcp",
       "env": {
         "HINDSIGHT_API_TOKEN": "<yourtoken>",
-        "DEFAULT_AGENT_ID": "<youragentid>",
-        "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+        "DEFAULT_AGENT_ID": "<youragentid>"
       }
     }
   }
@@ -82,8 +81,7 @@ const claudeConfigSnippet = `claude mcp add-json hindsight-mcp '{
   "command": "hindsight-mcp",
   "env": {
     "HINDSIGHT_API_TOKEN": "<yourtoken>",
-    "DEFAULT_AGENT_ID": "<youragentid>",
-    "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+    "DEFAULT_AGENT_ID": "<youragentid>"
   }
 }'`;
 
@@ -93,8 +91,7 @@ const clineConfigSnippet = `{
       "command": "hindsight-mcp",
       "env": {
         "HINDSIGHT_API_TOKEN": "<yourtoken>",
-        "DEFAULT_AGENT_ID": "<youragentid>",
-        "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+        "DEFAULT_AGENT_ID": "<youragentid>"
       },
       "disabled": false
     }
@@ -109,8 +106,7 @@ const roocodeConfigSnippet = `{
       "command": "hindsight-mcp",
       "env": {
         "HINDSIGHT_API_TOKEN": "<yourtoken>",
-        "DEFAULT_AGENT_ID": "<youragentid>",
-        "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+        "DEFAULT_AGENT_ID": "<youragentid>"
       }
     }
   ]
@@ -123,8 +119,7 @@ const copilotConfigSnippet = `{
       "command": "hindsight-mcp",
       "env": {
         "HINDSIGHT_API_TOKEN": "<yourtoken>",
-        "DEFAULT_AGENT_ID": "<youragentid>",
-        "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+        "DEFAULT_AGENT_ID": "<youragentid>"
       }
     }
   }
@@ -136,8 +131,7 @@ const forgecodeConfigSnippet = `{
       "command": "hindsight-mcp",
       "env": {
         "HINDSIGHT_API_TOKEN": "<yourtoken>",
-        "DEFAULT_AGENT_ID": "<youragentid>",
-        "DEFAULT_CONVERSATION_ID": "f47ac10b-58cc-4372-a567-0123456789ab"
+        "DEFAULT_AGENT_ID": "<youragentid>"
       }
     }
   }
@@ -145,7 +139,7 @@ const forgecodeConfigSnippet = `{
 
 const openhandsConfigSnippet = `[mcp]
 stdio_servers = [
-  {name = "hindsight-mcp", command = "hindsight-mcp", env = { HINDSIGHT_API_TOKEN = "<yourtoken>", DEFAULT_AGENT_ID = "<youragentid>", DEFAULT_CONVERSATION_ID = "f47ac10b-58cc-4372-a567-0123456789ab" }}
+  {name = "hindsight-mcp", command = "hindsight-mcp", env = { HINDSIGHT_API_TOKEN = "<yourtoken>", DEFAULT_AGENT_ID = "<youragentid>" }}
 ]`;
 
 const sharedMarkdownDetail = 'Document retrieval-first and reflection-last workflow rules using the template below so teammates stay in parity.';

--- a/mcp-servers/hindsight-mcp/README.md
+++ b/mcp-servers/hindsight-mcp/README.md
@@ -55,7 +55,7 @@ npm install && npm run build && npm link
 
 | Tool | Description |
 | --- | --- |
-| `create_memory_block` | Create a new memory block. Requires `content` **and** `lessons_learned`. `agent_id` must reference an existing agent¹; `conversation_id` can be any UUID². Falls back to env defaults when omitted. Optional: `errors`, `metadata` (JSON). |
+| `create_memory_block` | Create a new memory block. Requires `content` **and** `lessons_learned`. `agent_id` must reference an existing agent¹. `conversation_id` is optional; when omitted the server auto-generates one and returns it for reuse. Optional: `errors`, `metadata` (JSON). |
 | `create_agent` | Create a new agent. `agent_name` is required. Scope is derived from `HINDSIGHT_ORGANIZATION_ID` when set, otherwise from the token's embedded organization³. |
 | `retrieve_relevant_memories` | Retrieve memories for keywords (comma-separated string or array). Optional `limit`. Uses the resolved agent context and errors if the agent is unknown¹. |
 | `retrieve_all_memory_blocks` | Page through memory blocks for the current agent. Optional `limit`. Requires a valid agent context¹. |
@@ -63,10 +63,10 @@ npm install && npm run build && npm link
 | `report_memory_feedback` | Record positive/negative/neutral feedback on a memory block. Optional `feedback_details`. |
 | `get_memory_details` | Return metadata and content for one memory block by ID. |
 | `search_agents` | Search agent names via a query string. |
-| `advanced_search_memories` | Run full-text, semantic, or hybrid search. Accepts optional `agent_id` / `conversation_id` arguments and falls back to the environment. Requires a valid agent context¹. Tuning knobs: `limit`, `min_score`, `similarity_threshold`, `fulltext_weight`, `semantic_weight`, `min_combined_score`, `include_archived`. |
+| `advanced_search_memories` | Run full-text, semantic, or hybrid search. Accepts optional `agent_id` (falls back to env) and optional `conversation_id` filters. Requires a valid agent context¹. Tuning knobs: `limit`, `min_score`, `similarity_threshold`, `fulltext_weight`, `semantic_weight`, `min_combined_score`, `include_archived`. |
 | `whoami` | Return the authenticated user and memberships as seen by the Hindsight service. |
 
-> **Usage notes:** ¹ Agent IDs must exist; the service returns an error if the resolved agent is unknown. ² Conversation IDs can be any UUID—new values are accepted when writing or searching memories. ³ If `HINDSIGHT_ORGANIZATION_ID` is set it overrides the token's organization scope; a mismatch between the env override and the token causes an error. We recommend issuing organization-scoped tokens and leaving the override unset to avoid configuration drift.
+> **Usage notes:** ¹ Agent IDs must exist; the service returns an error if the resolved agent is unknown. ² If no `conversation_id` is supplied when creating a memory, the server generates one and returns it (any UUID is accepted when you provide one explicitly). ³ If `HINDSIGHT_ORGANIZATION_ID` is set it overrides the token's organization scope; a mismatch between the env override and the token causes an error. We recommend issuing organization-scoped tokens and leaving the override unset to avoid configuration drift.
 
 ## Core Configuration: Environment & Authentication
 
@@ -84,11 +84,11 @@ Configuration is driven entirely through environment variables so secrets never 
 | --- | --- |
 | `HINDSIGHT_API_BASE_URL` | Base URL override. Defaults to `https://api.hindsight-ai.com`; set this only for self-hosted or local deployments. |
 | `DEFAULT_AGENT_ID` | Fallback agent UUID when a tool omits `agent_id`. Must reference an existing agent. |
-| `DEFAULT_CONVERSATION_ID` | Fallback conversation UUID when a tool omits `conversation_id`. Any UUID is acceptable; new values are created as needed. |
+| `DEFAULT_CONVERSATION_ID` | Optional fallback conversation UUID when you want every request to reuse a fixed conversation. When omitted, the server auto-generates one during `create_memory_block` and returns it for future calls. |
 | `HINDSIGHT_ACTIVE_SCOPE` | Override scope header (`personal`, `organization`, `public`). Defaults based on token/org inference. |
 | `HINDSIGHT_ORGANIZATION_ID` | Organization override. Takes precedence over the token scope—set sparingly and ensure it matches the token’s organization. |
 
-> **Important:** The server does not automatically discover agent or conversation IDs. Supply them via arguments or environment; otherwise the request fails with `InvalidParams`.
+> **Important:** The server does not automatically discover agent IDs. Supply them via arguments or environment; otherwise the request fails with `InvalidParams`. When a `conversation_id` is missing during `create_memory_block`, a new UUID is generated and returned in the response so downstream calls can reuse it.
 
 ### Authentication, scope & security
 
@@ -137,7 +137,6 @@ Different MCP clients use different configuration mechanisms (JSON/TOML/YAML fil
       "timeout": 60,
       "env": {
         "DEFAULT_AGENT_ID": "00000000-0000-0000-0000-000000000000",
-        "DEFAULT_CONVERSATION_ID": "00000000-0000-0000-0000-000000000000",
         "HINDSIGHT_API_TOKEN": "hs_pat_xxx"
       }
     }
@@ -163,7 +162,6 @@ Install the [Cline extension](https://github.com/cline/cline) and make sure the 
 ```json
 {
   "DEFAULT_AGENT_ID": "00000000-0000-0000-0000-000000000000",
-  "DEFAULT_CONVERSATION_ID": "00000000-0000-0000-0000-000000000000",
   "HINDSIGHT_API_TOKEN": "hs_pat_xxx"
 }
 ```
@@ -189,7 +187,6 @@ Install the [Cline extension](https://github.com/cline/cline) and make sure the 
     "transport": "stdio",
     "env": {
       "DEFAULT_AGENT_ID": "00000000-0000-0000-0000-000000000000",
-      "DEFAULT_CONVERSATION_ID": "00000000-0000-0000-0000-000000000000",
       "HINDSIGHT_API_TOKEN": "hs_pat_xxx"
     }
   }
@@ -213,7 +210,6 @@ command = "hindsight-mcp"
 args = []
 env = {
   DEFAULT_AGENT_ID = "00000000-0000-0000-0000-000000000000",
-  DEFAULT_CONVERSATION_ID = "00000000-0000-0000-0000-000000000000",
   HINDSIGHT_API_TOKEN = "hs_pat_your_token_here"
 }
 ```

--- a/mcp-servers/hindsight-mcp/docs/client-config.json
+++ b/mcp-servers/hindsight-mcp/docs/client-config.json
@@ -60,7 +60,7 @@
       "codeSamples": [
         {
           "language": "json",
-          "code": "{\n  \"mcpServers\": {\n    \"hindsight-mcp\": {\n      \"command\": \"hindsight-mcp\",\n      \"transportType\": \"stdio\",\n      \"timeout\": 60,\n      \"env\": {\n        \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n        \"DEFAULT_CONVERSATION_ID\": \"00000000-0000-0000-0000-000000000000\",\n        \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n      }\n    }\n  }\n}"
+          "code": "{\n  \"mcpServers\": {\n    \"hindsight-mcp\": {\n      \"command\": \"hindsight-mcp\",\n      \"transportType\": \"stdio\",\n      \"timeout\": 60,\n      \"env\": {\n        \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n        \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n      }\n    }\n  }\n}"
         }
       ],
       "notes": [
@@ -79,7 +79,7 @@
       "codeSamples": [
         {
           "language": "json",
-          "code": "{\n  \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n  \"DEFAULT_CONVERSATION_ID\": \"00000000-0000-0000-0000-000000000000\",\n  \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n}"
+          "code": "{\n  \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n  \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n}"
         }
       ],
       "notes": [
@@ -97,7 +97,7 @@
       "codeSamples": [
         {
           "language": "json",
-          "code": "\"claudeCode.mcpServers\": [\n  {\n    \"name\": \"hindsight-mcp\",\n    \"command\": \"hindsight-mcp\",\n    \"transport\": \"stdio\",\n    \"env\": {\n      \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n      \"DEFAULT_CONVERSATION_ID\": \"00000000-0000-0000-0000-000000000000\",\n      \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n    }\n  }\n]"
+          "code": "\"claudeCode.mcpServers\": [\n  {\n    \"name\": \"hindsight-mcp\",\n    \"command\": \"hindsight-mcp\",\n    \"transport\": \"stdio\",\n    \"env\": {\n      \"DEFAULT_AGENT_ID\": \"00000000-0000-0000-0000-000000000000\",\n      \"HINDSIGHT_API_TOKEN\": \"hs_pat_xxx\"\n    }\n  }\n]"
         }
       ]
     },
@@ -112,7 +112,7 @@
       "codeSamples": [
         {
           "language": "toml",
-          "code": "[mcp_servers.hindsight-mcp]\ncommand = \"hindsight-mcp\"\nargs = []\nenv = {\n  DEFAULT_AGENT_ID = \"00000000-0000-0000-0000-000000000000\",\n  DEFAULT_CONVERSATION_ID = \"00000000-0000-0000-0000-000000000000\",\n  HINDSIGHT_API_TOKEN = \"hs_pat_your_token_here\"\n}"
+          "code": "[mcp_servers.hindsight-mcp]\ncommand = \"hindsight-mcp\"\nargs = []\nenv = {\n  DEFAULT_AGENT_ID = \"00000000-0000-0000-0000-000000000000\",\n  HINDSIGHT_API_TOKEN = \"hs_pat_your_token_here\"\n}"
         }
       ],
       "notes": [

--- a/mcp-servers/hindsight-mcp/package-lock.json
+++ b/mcp-servers/hindsight-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hindsight-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Unlicense",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",

--- a/mcp-servers/hindsight-mcp/package.json
+++ b/mcp-servers/hindsight-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Model Context Protocol server for the Hindsight AI memory service",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/mcp-servers/hindsight-mcp/src/index.ts
+++ b/mcp-servers/hindsight-mcp/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { randomUUID } from "crypto";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -12,9 +13,17 @@ import axios, { AxiosError } from 'axios';
 import { MemoryServiceClient, MemoryServiceClientConfig, CreateMemoryBlockPayload, RetrieveMemoriesPayload, ReportFeedbackPayload, MemoryBlock, Agent, CreateAgentPayload, AdvancedSearchPayload } from './client/MemoryServiceClient';
 
 // --- Configuration ---
+const normalizeUuid = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
 const API_BASE_URL = process.env.HINDSIGHT_API_BASE_URL || 'https://api.hindsight-ai.com'; // Default to hosted API
-const DEFAULT_AGENT_ID = process.env.DEFAULT_AGENT_ID;
-const DEFAULT_CONVERSATION_ID = process.env.DEFAULT_CONVERSATION_ID;
+const DEFAULT_AGENT_ID = normalizeUuid(process.env.DEFAULT_AGENT_ID);
+const DEFAULT_CONVERSATION_ID = normalizeUuid(process.env.DEFAULT_CONVERSATION_ID);
 const API_TOKEN = process.env.HINDSIGHT_API_TOKEN || process.env.HINDSIGHT_API_KEY;
 const API_HEADER: 'Authorization' | 'X-API-Key' = process.env.HINDSIGHT_API_KEY ? 'X-API-Key' : 'Authorization';
 const ACTIVE_SCOPE_ENV = process.env.HINDSIGHT_ACTIVE_SCOPE as ('personal' | 'organization' | 'public' | undefined);
@@ -130,7 +139,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "create_memory_block",
-        description: "Create a new memory block in the AI agent memory service. Requires agent_id, a valid UUID for conversation_id, and content/lessons_learned.",
+        description: "Create a new memory block in the AI agent memory service. conversation_id is optional; one is generated when omitted.",
         inputSchema: {
           type: "object",
           properties: {
@@ -140,7 +149,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             conversation_id: {
               type: "string",
-              description: "UUID of the conversation (this value should not be provided, it will be filled automatically by env variables).",
+              description: "Optional UUID of the conversation. If omitted, a new conversation_id is generated and returned in the response.",
             },
             content: {
               type: "string",
@@ -196,7 +205,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             conversation_id: {
               type: "string",
-              description: "UUID of the conversation (this value should not be provided, it will be filled automatically by env variables).",
+              description: "Optional conversation UUID to narrow context when desired.",
             },
             limit: {
               type: "number",
@@ -232,7 +241,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             conversation_id: {
               "type": "string",
-              "description": "UUID of the conversation to retrieve memories for (this value should not be provided, it will be filled automatically by env variables).",
+              "description": "UUID of the conversation to retrieve memories for (provide the value returned from create_memory_block or a configured default).",
             },
             agent_id: {
               "type": "string",
@@ -322,7 +331,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             conversation_id: {
               type: "string",
-              description: "Optional conversation UUID. Falls back to DEFAULT_CONVERSATION_ID when omitted.",
+              description: "Optional conversation UUID filter.",
             },
             limit: {
               type: "number",
@@ -375,14 +384,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     // --- create_memory_block ---
     if (toolName === "create_memory_block") {
-      const agent_id = (typedArgs?.agent_id as string | undefined) || DEFAULT_AGENT_ID;
-      const conversation_id = (typedArgs?.conversation_id as string | undefined) || DEFAULT_CONVERSATION_ID;
+      const agent_id = normalizeUuid(typedArgs?.agent_id) || DEFAULT_AGENT_ID;
+      const providedConversationId = normalizeUuid(typedArgs?.conversation_id);
+      const fallbackConversationId = DEFAULT_CONVERSATION_ID;
+      const conversation_id = providedConversationId || fallbackConversationId || randomUUID();
+      const generatedConversationId = !providedConversationId && !fallbackConversationId;
 
       if (!agent_id) {
         throw new McpError(ErrorCode.InvalidParams, "Agent ID is required for create_memory_block and not provided via arguments or DEFAULT_AGENT_ID environment variable.");
-      }
-      if (!conversation_id) {
-        throw new McpError(ErrorCode.InvalidParams, "Conversation ID is required for create_memory_block and not provided via arguments or DEFAULT_CONVERSATION_ID environment variable.");
       }
 
       const payload: CreateMemoryBlockPayload = {
@@ -405,8 +414,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         );
       }
       const result = await memoryServiceClient.createMemoryBlock(payload);
+      let responseText = `Successfully created memory block with ID: ${result.id}. Conversation ID: ${conversation_id}.`;
+      if (generatedConversationId) {
+        responseText += ' Use this conversation_id for future MCP tool calls to continue the discussion context.';
+      }
       return {
-        content: [{ type: "text", text: `Successfully created memory block with ID: ${result.id}` }]
+        content: [{ type: "text", text: responseText }]
       };
     }
 
@@ -434,7 +447,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     // --- retrieve_all_memory_blocks ---
     else if (toolName === "retrieve_all_memory_blocks") {
-      const agent_id = (typedArgs?.agent_id as string | undefined) || DEFAULT_AGENT_ID;
+      const agent_id = normalizeUuid(typedArgs?.agent_id) || DEFAULT_AGENT_ID;
       const limit = typedArgs?.limit as number | undefined;
 
       if (!agent_id) {
@@ -460,12 +473,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     // --- retrieve_memory_blocks_by_conversation_id ---
     else if (toolName === "retrieve_memory_blocks_by_conversation_id") {
-      const conversation_id = (typedArgs?.conversation_id as string | undefined) || DEFAULT_CONVERSATION_ID;
-      const agent_id = (typedArgs?.agent_id as string | undefined) || DEFAULT_AGENT_ID;
+      const conversation_id = normalizeUuid(typedArgs?.conversation_id) || DEFAULT_CONVERSATION_ID;
+      const agent_id = normalizeUuid(typedArgs?.agent_id) || DEFAULT_AGENT_ID;
       const limit = typedArgs?.limit as number | undefined;
 
       if (!conversation_id) {
-        throw new McpError(ErrorCode.InvalidParams, "Conversation ID is required for retrieve_memory_blocks_by_conversation_id and not provided via arguments or DEFAULT_CONVERSATION_ID environment variable.");
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          "Conversation ID is required for retrieve_memory_blocks_by_conversation_id. Use the conversation_id returned from create_memory_block or configure DEFAULT_CONVERSATION_ID."
+        );
       }
 
       const result = await memoryServiceClient.getMemoryBlocksByConversationId(
@@ -486,8 +502,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     // --- retrieve_relevant_memories ---
     else if (toolName === "retrieve_relevant_memories") {
-      const agent_id = (typedArgs?.agent_id as string | undefined) || DEFAULT_AGENT_ID;
-      const conversation_id = (typedArgs?.conversation_id as string | undefined) || DEFAULT_CONVERSATION_ID;
+      const agent_id = normalizeUuid(typedArgs?.agent_id) || DEFAULT_AGENT_ID;
+      const conversation_id = normalizeUuid(typedArgs?.conversation_id);
 
       if (!typedArgs.keywords) {
         throw new McpError(ErrorCode.InvalidParams, "Invalid arguments for retrieve_relevant_memories. 'keywords' is required as a comma-separated string or array of strings.");
@@ -517,9 +533,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const payload: RetrieveMemoriesPayload = {
         keywords: keywordCsv,
         agent_id: agent_id,
-        conversation_id: conversation_id,
         limit: typedArgs.limit,
       };
+      if (conversation_id) {
+        payload.conversation_id = conversation_id;
+      }
 
       if (!isValidRetrieveMemoriesPayload(payload)) {
         throw new McpError(ErrorCode.InvalidParams, "Invalid arguments for retrieve_relevant_memories. Keywords must resolve to a non-empty string.");
@@ -598,12 +616,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Invalid arguments for advanced_search_memories. Requires 'search_query' (string).");
       }
 
-      const agent_id: string | undefined = (typeof typedArgs.agent_id === 'string' && typedArgs.agent_id.trim().length > 0)
-        ? typedArgs.agent_id.trim()
-        : DEFAULT_AGENT_ID;
-      const conversation_id: string | undefined = (typeof typedArgs.conversation_id === 'string' && typedArgs.conversation_id.trim().length > 0)
-        ? typedArgs.conversation_id.trim()
-        : DEFAULT_CONVERSATION_ID;
+      const agent_id: string | undefined = normalizeUuid(typedArgs?.agent_id) || DEFAULT_AGENT_ID;
+      const conversation_id: string | undefined = normalizeUuid(typedArgs?.conversation_id);
 
       const st: string = typedArgs.search_type || 'fulltext';
       const q: string = typedArgs.search_query;


### PR DESCRIPTION
This pull request updates the handling and documentation of the `conversation_id` parameter in the Hindsight MCP server and its client configuration examples. The main change is that `conversation_id` is now fully optional when creating memory blocks: if omitted, the server will generate a new one and return it for reuse. The PR also removes `DEFAULT_CONVERSATION_ID` from all sample configurations and clarifies related documentation, making setup and usage simpler and less error-prone.

**Configuration and Documentation Updates:**

* Removed `DEFAULT_CONVERSATION_ID` from all example configuration snippets and client config files, reflecting that it is now optional and not required for basic setup. (`apps/hindsight-dashboard/src/components/GetStartedModal.tsx` [[1]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L57-R57) [[2]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L73-R73) [[3]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L85-R84) [[4]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L96-R94) [[5]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L112-R109) [[6]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L126-R122) [[7]](diffhunk://#diff-e4906a380c07ad17eca5b9eaafeee4dd06c2525798cbf02b107eeb62cdd9b546L139-R142); `mcp-servers/hindsight-mcp/docs/client-config.json` [[8]](diffhunk://#diff-10b5e42fb64cf0e728d0ab45623f64ea743dbe768e01468d09e284ee1a7e93e2L63-R63) [[9]](diffhunk://#diff-10b5e42fb64cf0e728d0ab45623f64ea743dbe768e01468d09e284ee1a7e93e2L82-R82) [[10]](diffhunk://#diff-10b5e42fb64cf0e728d0ab45623f64ea743dbe768e01468d09e284ee1a7e93e2L100-R100) [[11]](diffhunk://#diff-10b5e42fb64cf0e728d0ab45623f64ea743dbe768e01468d09e284ee1a7e93e2L115-R115)
* Updated the README to clarify that `conversation_id` is optional for `create_memory_block`, and when omitted, the server generates and returns a new UUID for future use. Also updated usage notes and removed `DEFAULT_CONVERSATION_ID` from sample environment blocks. (`mcp-servers/hindsight-mcp/README.md` [[1]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L58-R69) [[2]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L87-R91) [[3]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L140) [[4]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L166) [[5]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L192) [[6]](diffhunk://#diff-c743cd4a3dce516683d3f18ac38418949f19155cf3f57dbe2ad5555d073cfee1L216)

**Server Implementation and API Schema:**

* Updated the API schema and tool descriptions to indicate that `conversation_id` is optional for memory creation and searching, and clarified the behavior in the OpenAPI-style schemas and tool descriptions. (`mcp-servers/hindsight-mcp/src/index.ts` [[1]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675L133-R142) [[2]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675L143-R152) [[3]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675L199-R208) [[4]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675L235-R244) [[5]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675L325-R334)
* Added a utility to normalize UUID environment variables, ensuring empty strings are treated as undefined. (`mcp-servers/hindsight-mcp/src/index.ts` [mcp-servers/hindsight-mcp/src/index.tsR16-R26](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675R16-R26))

**Version Bump:**

* Bumped the MCP server package version from `1.0.0` to `1.0.1` to reflect these changes. (`mcp-servers/hindsight-mcp/package.json` [[1]](diffhunk://#diff-e1c84b6a36a28a6630a175d69e37e75b430dffecb79e47dc9569ef9bba02addbL3-R3) `mcp-servers/hindsight-mcp/package-lock.json` [[2]](diffhunk://#diff-cd1c14bde2b66e75e5c9ac9e0b2d4563d2bced873aa0d5d3d2d96475a2debfc6L3-R9)