### PR TITLE
feat: add CLI version command and update package version to 1.0.4

### DIFF
--- a/mcp-servers/hindsight-mcp/README.md
+++ b/mcp-servers/hindsight-mcp/README.md
@@ -51,6 +51,12 @@ cd /absolute/path/to/hindsight-ai/mcp-servers/hindsight-mcp
 npm install && npm run build && npm link
 ```
 
+Verify the binary resolves on your `PATH` and report its version:
+
+```bash
+hindsight-mcp --version
+```
+
 ## Available Tools
 
 | Tool | Description |

--- a/mcp-servers/hindsight-mcp/package-lock.json
+++ b/mcp-servers/hindsight-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hindsight-mcp",
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "Unlicense",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",

--- a/mcp-servers/hindsight-mcp/package.json
+++ b/mcp-servers/hindsight-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "Model Context Protocol server for the Hindsight AI memory service",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/mcp-servers/hindsight-mcp/src/index.ts
+++ b/mcp-servers/hindsight-mcp/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from "fs";
+import path from "path";
 import { randomUUID } from "crypto";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -11,6 +13,29 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosError } from 'axios';
 import { MemoryServiceClient, MemoryServiceClientConfig, CreateMemoryBlockPayload, RetrieveMemoriesPayload, ReportFeedbackPayload, MemoryBlock, Agent, CreateAgentPayload, AdvancedSearchPayload } from './client/MemoryServiceClient';
+
+const resolvePackageVersion = (): string => {
+  try {
+    const pkgPath = path.resolve(__dirname, "../package.json");
+    const pkgRaw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(pkgRaw) as { version?: string };
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch (error) {
+    console.warn("[hindsight-mcp] Unable to determine package version:", error);
+    return "unknown";
+  }
+};
+
+const maybeHandleCliVersion = () => {
+  const args = process.argv.slice(2);
+  if (args.includes("--version") || args.includes("-v")) {
+    const version = resolvePackageVersion();
+    console.log(`hindsight-mcp ${version}`);
+    process.exit(0);
+  }
+};
+
+maybeHandleCliVersion();
 
 // --- Configuration ---
 const normalizeUuid = (value: unknown): string | undefined => {


### PR DESCRIPTION
This pull request introduces a new CLI feature to the `hindsight-mcp` server, allowing users to check the installed version with a `--version` flag. It also updates the package version to `1.0.4` and makes minor improvements to documentation.

**New CLI feature:**

* Added logic in `src/index.ts` to handle `--version`/`-v` CLI flags, printing the current package version and exiting. This includes a helper function to resolve the version from `package.json`. [[1]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675R3-R4) [[2]](diffhunk://#diff-0582483110a3c59683d5ea4816147f3adec9effbffcce529a6bbfa6c112f8675R17-R39)

**Version bump:**

* Updated the version in both `package.json` and `package-lock.json` from `1.0.1` to `1.0.4`. [[1]](diffhunk://#diff-e1c84b6a36a28a6630a175d69e37e75b430dffecb79e47dc9569ef9bba02addbL3-R3) [[2]](diffhunk://#diff-cd1c14bde2b66e75e5c9ac9e0b2d4563d2bced873aa0d5d3d2d96475a2debfc6L3-R9)

**Documentation update:**

* Added instructions in `README.md` for verifying the CLI binary and checking its version.