### PR TITLE
fix: update version number to 1.1.3 in package.json and package-lock.…

### DIFF
--- a/mcp-servers/hindsight-mcp/package-lock.json
+++ b/mcp-servers/hindsight-mcp/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hindsight-mcp",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Unlicense",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",
-        "axios": "^1.7.2",
-        "hindsight-mcp": "1.1.1"
+        "axios": "^1.7.2"
       },
       "bin": {
         "hindsight-mcp": "build/index.js"

--- a/mcp-servers/hindsight-mcp/package.json
+++ b/mcp-servers/hindsight-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hindsight-mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Model Context Protocol server for the Hindsight AI memory service",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -60,7 +60,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",
-    "axios": "^1.7.2",
-    "hindsight-mcp": "1.1.1"
+    "axios": "^1.7.2"
   }
 }


### PR DESCRIPTION
This pull request updates the version of the `hindsight-mcp` package and cleans up its dependencies by removing a redundant self-dependency. These changes help ensure the package metadata and dependency list are accurate and up to date.

**Version update:**
- Bumped the `hindsight-mcp` package version from `1.1.2` to `1.1.3` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-e1c84b6a36a28a6630a175d69e37e75b430dffecb79e47dc9569ef9bba02addbL3-R3) [[2]](diffhunk://#diff-cd1c14bde2b66e75e5c9ac9e0b2d4563d2bced873aa0d5d3d2d96475a2debfc6L3-R13)

**Dependency cleanup:**
- Removed the unnecessary `hindsight-mcp` self-dependency from the `dependencies` section in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-e1c84b6a36a28a6630a175d69e37e75b430dffecb79e47dc9569ef9bba02addbL63-R63) [[2]](diffhunk://#diff-cd1c14bde2b66e75e5c9ac9e0b2d4563d2bced873aa0d5d3d2d96475a2debfc6L3-R13)