### PR TITLE
Security audit: data-isolation fixes (F1, F2, F3, F6, A, B, D, E)

### DIFF
--- a/apps/hindsight-service/core/api/agents.py
+++ b/apps/hindsight-service/core/api/agents.py
@@ -149,7 +149,10 @@ def get_agent_endpoint(
             x_forwarded_email=x_forwarded_email,
         )
         if email:
-            u = get_or_create_user(db, email=email, display_name=name)
+            u = get_or_create_user(
+                db, email=email, display_name=name,
+                external_subject=name, auth_provider="oauth2_proxy",
+            )
             memberships = get_user_memberships(db, u.id)
             current_user = {
                 "id": u.id,
@@ -198,7 +201,10 @@ def search_agents_endpoint(
             x_forwarded_email=x_forwarded_email,
         )
         if email:
-            u = get_or_create_user(db, email=email, display_name=name)
+            u = get_or_create_user(
+                db, email=email, display_name=name,
+                external_subject=name, auth_provider="oauth2_proxy",
+            )
             memberships = get_user_memberships(db, u.id)
             current_user = {
                 "id": u.id,

--- a/apps/hindsight-service/core/api/agents.py
+++ b/apps/hindsight-service/core/api/agents.py
@@ -21,6 +21,7 @@ from core.utils.scopes import (
 from core.api.deps import (
     get_current_user_context,
     get_current_user_context_or_pat,
+    get_or_create_user_for_request,
     ensure_pat_allows_write,
     ensure_pat_allows_read,
     get_scoped_user_and_context,
@@ -149,10 +150,7 @@ def get_agent_endpoint(
             x_forwarded_email=x_forwarded_email,
         )
         if email:
-            u = get_or_create_user(
-                db, email=email, display_name=name,
-                external_subject=name, auth_provider="oauth2_proxy",
-            )
+            u = get_or_create_user_for_request(db, email=email, name=name)
             memberships = get_user_memberships(db, u.id)
             current_user = {
                 "id": u.id,
@@ -201,10 +199,7 @@ def search_agents_endpoint(
             x_forwarded_email=x_forwarded_email,
         )
         if email:
-            u = get_or_create_user(
-                db, email=email, display_name=name,
-                external_subject=name, auth_provider="oauth2_proxy",
-            )
+            u = get_or_create_user_for_request(db, email=email, name=name)
             memberships = get_user_memberships(db, u.id)
             current_user = {
                 "id": u.id,

--- a/apps/hindsight-service/core/api/auth.py
+++ b/apps/hindsight-service/core/api/auth.py
@@ -84,6 +84,18 @@ def get_or_create_user(
         db.add(user)
         was_new = True
     elif external_subject is not None:
+        # If the IdP's user-id claim is set to the email itself (oauth2-proxy
+        # default `preferred_username` for Google), every external_subject
+        # equals the email and the binding can never distinguish two humans
+        # sharing an email. Warn loudly so the operator notices the config is
+        # not providing the protection it should.
+        if external_subject == email:
+            logger.warning(
+                "auth_subject_is_email: external_subject==email for %s — "
+                "set OAUTH2_PROXY_USER_ID_CLAIM=sub (or equivalent) so the "
+                "external_subject binding can actually catch email-reuse.",
+                email,
+            )
         # Identity binding for existing rows:
         #   - row has no bound subject -> bind it (TOFU; covers legacy users)
         #   - row's subject matches    -> ok

--- a/apps/hindsight-service/core/api/auth.py
+++ b/apps/hindsight-service/core/api/auth.py
@@ -100,7 +100,27 @@ def get_or_create_user(
         #   - row has no bound subject -> bind it (TOFU; covers legacy users)
         #   - row's subject matches    -> ok
         #   - row's subject differs    -> refuse (account inheritance attempt)
+        # Race protection: re-fetch the row with FOR UPDATE inside the bind
+        # branch so two concurrent first-time logins serialise; the loser
+        # observes the winner's bound external_subject and either matches
+        # (same identity) or raises IdentityMismatchError. The DB also has a
+        # partial unique index on users.external_subject as a final guard.
         existing_sub = getattr(user, "external_subject", None)
+        if not existing_sub:
+            try:
+                locked = (
+                    db.query(models.User)
+                    .filter(models.User.id == user.id)
+                    .with_for_update()
+                    .first()
+                )
+            except Exception:
+                # SQLite (test-only) and other dialects without row locking;
+                # fall back to the un-locked path.
+                locked = user
+            if locked is not None:
+                user = locked
+                existing_sub = getattr(user, "external_subject", None)
         if not existing_sub:
             user.external_subject = external_subject
             if auth_provider is not None and not getattr(user, "auth_provider", None):

--- a/apps/hindsight-service/core/api/auth.py
+++ b/apps/hindsight-service/core/api/auth.py
@@ -56,7 +56,21 @@ def resolve_identity_from_headers(
     return user, email
 
 
-def get_or_create_user(db: Session, email: str, display_name: Optional[str] = None) -> models.User:
+class IdentityMismatchError(Exception):
+    """Raised when an authenticated request's external_subject does not
+    match the existing User row's bound external_subject. Defense against
+    email reassignment / IDP collisions: a recycled email cannot silently
+    inherit the previous owner's data."""
+
+
+def get_or_create_user(
+    db: Session,
+    email: str,
+    display_name: Optional[str] = None,
+    *,
+    external_subject: Optional[str] = None,
+    auth_provider: Optional[str] = None,
+) -> models.User:
     user = db.query(models.User).filter(models.User.email == email).first()
     was_new = False
     if not user:
@@ -64,9 +78,35 @@ def get_or_create_user(db: Session, email: str, display_name: Optional[str] = No
             email=email,
             display_name=display_name or email.split("@")[0],
             beta_access_status='not_requested',
+            external_subject=external_subject,
+            auth_provider=auth_provider,
         )
         db.add(user)
         was_new = True
+    elif external_subject is not None:
+        # Identity binding for existing rows:
+        #   - row has no bound subject -> bind it (TOFU; covers legacy users)
+        #   - row's subject matches    -> ok
+        #   - row's subject differs    -> refuse (account inheritance attempt)
+        existing_sub = getattr(user, "external_subject", None)
+        if not existing_sub:
+            user.external_subject = external_subject
+            if auth_provider is not None and not getattr(user, "auth_provider", None):
+                user.auth_provider = auth_provider
+            try:
+                db.commit()
+                db.refresh(user)
+            except Exception:
+                db.rollback()
+        elif existing_sub != external_subject:
+            logger.warning(
+                "identity_mismatch: email=%s existing_subject=%s incoming_subject=%s",
+                email, existing_sub, external_subject,
+            )
+            raise IdentityMismatchError(
+                "Account exists for this email but was first registered by a "
+                "different identity. Contact an administrator."
+            )
 
     # Elevate to superadmin based on ADMIN_EMAILS only at creation time to avoid test-order flakiness
     admins = _admin_emails()

--- a/apps/hindsight-service/core/api/bulk_operations.py
+++ b/apps/hindsight-service/core/api/bulk_operations.py
@@ -68,6 +68,24 @@ async def bulk_move(
     if destination_organization_id and destination_owner_user_id:
         raise HTTPException(status_code=422, detail="Cannot specify both destination_organization_id and destination_owner_user_id")
 
+    # Recipient consent: a non-superadmin actor may only move data to *their own*
+    # personal scope. Otherwise the bulk-move endpoint can be used to dump org
+    # data into an unrelated user's personal scope without that user's knowledge.
+    if destination_owner_user_id:
+        try:
+            dest_user_uuid = (
+                destination_owner_user_id if isinstance(destination_owner_user_id, uuid.UUID)
+                else uuid.UUID(str(destination_owner_user_id))
+            )
+        except Exception:
+            raise HTTPException(status_code=422, detail="Invalid destination_owner_user_id")
+        if not current_user.get("is_superadmin"):
+            if dest_user_uuid != getattr(user, "id", None):
+                raise HTTPException(
+                    status_code=403,
+                    detail="destination_owner_user_id must match the requesting user (only superadmins may move to a different user's personal scope)",
+                )
+
     # Helper: robust membership check that tolerates different shapes and definitively verifies via DB.
     def _has_membership(_org_id) -> bool:
         try:

--- a/apps/hindsight-service/core/api/bulk_operations.py
+++ b/apps/hindsight-service/core/api/bulk_operations.py
@@ -153,21 +153,19 @@ async def bulk_move(
         _pytest_mode = False
 
     if dry_run:
-        # For planning, enforce destination membership when destination org is specified;
-        # otherwise require source org membership. Use only the provided current_user context
-        # to avoid cross-session DB flakiness.
+        # Planning requires source-org membership unconditionally — otherwise an
+        # outsider with dest-org membership could probe `agent_count`,
+        # `memory_block_count`, `keyword_count`, and name conflicts of any
+        # source org. When a destination org is specified, also require
+        # destination-org membership.
         is_super = bool(current_user.get("is_superadmin"))
+        memberships_by_org = current_user.get("memberships_by_org") or {}
+        if not (is_super or memberships_by_org.get(str(org_id))):
+            raise HTTPException(status_code=403, detail="Forbidden")
         if destination_organization_id:
             dest_id = uuid.UUID(str(destination_organization_id)) if not isinstance(destination_organization_id, uuid.UUID) else destination_organization_id
-            sid = str(dest_id)
-            mem = (current_user.get("memberships_by_org") or {}).get(sid)
-            if not (is_super or mem):
+            if not (is_super or memberships_by_org.get(str(dest_id))):
                 raise HTTPException(status_code=403, detail="Forbidden to move resources to the destination organization")
-        else:
-            sid = str(org_id)
-            mem = (current_user.get("memberships_by_org") or {}).get(sid)
-            if not (is_super or mem):
-                raise HTTPException(status_code=403, detail="Forbidden")
     else:
         # For actual execution, we require manage rights.
         if not can_manage_org_effective(org_id, current_user, db=db, user_id=user.id, allow_db_fallback=True):

--- a/apps/hindsight-service/core/api/bulk_operations.py
+++ b/apps/hindsight-service/core/api/bulk_operations.py
@@ -270,11 +270,15 @@ async def bulk_delete(
 ):
     user, current_user = user_context
     dry_run = payload.get("dry_run", True)
-    # Allow dry-run for members; require manage rights for execution
+    # Both dry-run (planning) and execution require source-org membership;
+    # execution additionally requires manage rights. Planning that bypasses
+    # membership leaks per-resource counts to outsiders.
+    is_super = bool(current_user.get("is_superadmin"))
     if dry_run:
-        # Allow planning without strict membership enforcement to enable safe previews.
-        # Execution (non-dry-run) remains protected below.
-        pass
+        sid = str(org_id)
+        mem = (current_user.get("memberships_by_org") or {}).get(sid)
+        if not (is_super or mem):
+            raise HTTPException(status_code=403, detail="Forbidden")
     else:
         if not can_manage_org_effective(org_id, current_user, db=db, user_id=user.id, allow_db_fallback=True):
             raise HTTPException(status_code=403, detail="Forbidden")

--- a/apps/hindsight-service/core/api/consolidation.py
+++ b/apps/hindsight-service/core/api/consolidation.py
@@ -182,6 +182,15 @@ def validate_consolidation_suggestion_endpoint(
         raise HTTPException(status_code=400, detail="Suggestion is not in pending status")
     if not _user_can_view_suggestion(db, suggestion, current_user):
         raise HTTPException(status_code=404, detail="Consolidation suggestion not found")
+    # Validating a consolidation archives every original and mints a new merged
+    # block. The previous "any one original readable" check let a user trigger
+    # archive of memory blocks they had no write access to. Require write on
+    # every original.
+    if not _user_can_write_suggestion(db, suggestion, current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="Cannot validate: you must have write access to every original memory block.",
+        )
     # PAT enforcement for write in org context (derive org if applicable)
     try:
         org_id = None
@@ -196,6 +205,13 @@ def validate_consolidation_suggestion_endpoint(
 
     try:
         crud.apply_consolidation(db, suggestion_id=suggestion_id)
+    except crud.ConsolidationOriginalMismatchError as exc:
+        logger.warning("Refused cross-owner consolidation %s: %s", suggestion_id, exc)
+        raise HTTPException(
+            status_code=409,
+            detail="Suggestion bundles originals with different scope/owner/org; cannot consolidate.",
+        )
+    try:
         updated = crud.get_consolidation_suggestion(db, suggestion_id=suggestion_id)
         if not updated:
             raise HTTPException(status_code=404, detail="Updated consolidation suggestion not found")

--- a/apps/hindsight-service/core/api/deps.py
+++ b/apps/hindsight-service/core/api/deps.py
@@ -15,11 +15,36 @@ from sqlalchemy.orm import Session
 
 from core.db.database import get_db
 from core.api.auth import (
+    IdentityMismatchError,
     resolve_identity_from_headers,
     get_or_create_user,
     get_user_memberships,
     is_beta_access_admin,
 )
+
+
+def _get_or_create_user_for_request(
+    db: Session,
+    *,
+    email: str,
+    name: Optional[str],
+):
+    """Wrapper used by FastAPI handlers; passes the X-Auth-Request-User
+    value as external_subject and translates IdentityMismatchError to 401.
+    """
+    try:
+        return get_or_create_user(
+            db,
+            email=email,
+            display_name=name,
+            external_subject=name,
+            auth_provider="oauth2_proxy",
+        )
+    except IdentityMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+        ) from exc
 from core.db import models
 from core.db.scope_utils import ScopeContext
 from core.db.repositories import tokens as token_repo
@@ -125,7 +150,7 @@ def get_current_user_context(
     )
     if not email:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-    user = get_or_create_user(db, email=email, display_name=name)
+    user = _get_or_create_user_for_request(db, email=email, name=name)
 
     # Normalize beta access status to reflect latest request state.
     from core.db.repositories import beta_access as beta_repo

--- a/apps/hindsight-service/core/api/deps.py
+++ b/apps/hindsight-service/core/api/deps.py
@@ -23,28 +23,29 @@ from core.api.auth import (
 )
 
 
-def _get_or_create_user_for_request(
+_OAUTH2_PROXY_PROVIDER = "oauth2_proxy"
+
+
+def get_or_create_user_for_request(
     db: Session,
     *,
     email: str,
     name: Optional[str],
 ):
-    """Wrapper used by FastAPI handlers; passes the X-Auth-Request-User
-    value as external_subject and translates IdentityMismatchError to 401.
+    """Single entry point used by every FastAPI handler that resolves a user
+    from oauth2-proxy headers. Threads `external_subject=name` through to
+    `get_or_create_user`; IdentityMismatchError is translated to 401 by the
+    global FastAPI exception handler in `core.api.main`. Centralising this
+    means callers can never silently skip the identity-binding check by
+    forgetting a kwarg.
     """
-    try:
-        return get_or_create_user(
-            db,
-            email=email,
-            display_name=name,
-            external_subject=name,
-            auth_provider="oauth2_proxy",
-        )
-    except IdentityMismatchError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(exc),
-        ) from exc
+    return get_or_create_user(
+        db,
+        email=email,
+        display_name=name,
+        external_subject=name,
+        auth_provider=_OAUTH2_PROXY_PROVIDER,
+    )
 from core.db import models
 from core.db.scope_utils import ScopeContext
 from core.db.repositories import tokens as token_repo
@@ -150,7 +151,7 @@ def get_current_user_context(
     )
     if not email:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-    user = _get_or_create_user_for_request(db, email=email, name=name)
+    user = get_or_create_user_for_request(db, email=email, name=name)
 
     # Normalize beta access status to reflect latest request state.
     from core.db.repositories import beta_access as beta_repo

--- a/apps/hindsight-service/core/api/main.py
+++ b/apps/hindsight-service/core/api/main.py
@@ -38,6 +38,7 @@ from core.api.auth import (
 from core.api.deps import (
     get_current_user_context,
     get_current_user_context_or_pat,
+    get_or_create_user_for_request,
     ensure_pat_allows_write,
     ensure_pat_allows_read,
     get_scoped_user_and_context,
@@ -94,6 +95,19 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Translate IdentityMismatchError (raised by core.api.auth.get_or_create_user
+# when a request's external_subject does not match the existing User row's
+# bound subject) into a clean 401, regardless of which handler was running.
+# Without this, the exception escaped through ~5 call sites as a 500 with the
+# mismatch detail in the response body.
+@app.exception_handler(IdentityMismatchError)
+async def _identity_mismatch_handler(_request: Request, _exc: IdentityMismatchError):
+    return JSONResponse(
+        {"authenticated": False, "detail": "Authentication denied."},
+        status_code=status.HTTP_401_UNAUTHORIZED,
+    )
 
 # Middleware: enforce read-only for unauthenticated requests
 @app.middleware("http")
@@ -403,16 +417,9 @@ def get_user_info(
     if not email:
         return {"authenticated": True, "user": name or None, "email": None}
 
-    try:
-        user = get_or_create_user(
-            db, email=email, display_name=name,
-            external_subject=name, auth_provider="oauth2_proxy",
-        )
-    except IdentityMismatchError as exc:
-        return JSONResponse(
-            {"authenticated": False, "detail": str(exc)},
-            status_code=status.HTTP_401_UNAUTHORIZED,
-        )
+    # IdentityMismatchError is translated to 401 by the global exception
+    # handler at the top of this module.
+    user = get_or_create_user_for_request(db, email=email, name=name)
     memberships = get_user_memberships(db, user.id)
     beta_admin = is_beta_access_admin(user.email) or bool(user.is_superadmin)
     return {
@@ -1084,10 +1091,7 @@ def search_memory_blocks_fulltext_endpoint(
                 x_forwarded_email=x_forwarded_email,
             )
             if email:
-                u = get_or_create_user(
-                    db, email=email, display_name=name,
-                    external_subject=name, auth_provider="oauth2_proxy",
-                )
+                u = get_or_create_user_for_request(db, email=email, name=name)
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,
@@ -1169,10 +1173,7 @@ def search_memory_blocks_semantic_endpoint(
             )
             current_user = None
             if email:
-                u = get_or_create_user(
-                    db, email=email, display_name=name,
-                    external_subject=name, auth_provider="oauth2_proxy",
-                )
+                u = get_or_create_user_for_request(db, email=email, name=name)
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,
@@ -1280,10 +1281,7 @@ def search_memory_blocks_hybrid_endpoint(
                 x_forwarded_email=x_forwarded_email,
             )
             if email:
-                u = get_or_create_user(
-                    db, email=email, display_name=name,
-                    external_subject=name, auth_provider="oauth2_proxy",
-                )
+                u = get_or_create_user_for_request(db, email=email, name=name)
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,

--- a/apps/hindsight-service/core/api/main.py
+++ b/apps/hindsight-service/core/api/main.py
@@ -358,18 +358,21 @@ def get_user_info(
         except HTTPException as e:
             return JSONResponse({"authenticated": False, "detail": e.detail}, status_code=e.status_code)
 
-    # Local dev fallback (no oauth, no PAT) when running on localhost
+    # Local dev fallback (no oauth, no PAT). Defaults to OFF; the previous
+    # default-on + Host: localhost* check was spoofable via the Host header
+    # whenever the backend was reachable without Traefik in front of it.
+    # Now we require: explicit opt-in via ALLOW_LOCAL_DEV_AUTH=true AND a
+    # loopback client_ip. The Host header is no longer consulted.
     try:
-        allow_local = os.getenv("ALLOW_LOCAL_DEV_AUTH", "true").lower() == "true"
+        allow_local = os.getenv("ALLOW_LOCAL_DEV_AUTH", "false").lower() == "true"
     except Exception:
-        allow_local = True
-    host = (request.headers.get('host') or '').lower()
+        allow_local = False
     client_ip = None
     try:
         client_ip = request.client.host if request.client else None
     except Exception:
         client_ip = None
-    is_local = allow_local and (host.startswith('localhost') or host.startswith('127.0.0.1') or client_ip in ('127.0.0.1', '::1', None))
+    is_local = allow_local and client_ip in ("127.0.0.1", "::1")
     if is_local and not any([x_auth_request_user, x_auth_request_email, x_forwarded_user, x_forwarded_email]):
         email = os.getenv('DEV_LOCAL_EMAIL', 'dev@localhost')
         name = os.getenv('DEV_LOCAL_NAME', 'Development User')

--- a/apps/hindsight-service/core/api/main.py
+++ b/apps/hindsight-service/core/api/main.py
@@ -29,6 +29,7 @@ from core.db.database import engine, get_db
 from core.pruning.pruning_service import get_pruning_service
 from core.pruning.compression_service import get_compression_service
 from core.api.auth import (
+    IdentityMismatchError,
     resolve_identity_from_headers,
     get_or_create_user,
     get_user_memberships,
@@ -402,7 +403,16 @@ def get_user_info(
     if not email:
         return {"authenticated": True, "user": name or None, "email": None}
 
-    user = get_or_create_user(db, email=email, display_name=name)
+    try:
+        user = get_or_create_user(
+            db, email=email, display_name=name,
+            external_subject=name, auth_provider="oauth2_proxy",
+        )
+    except IdentityMismatchError as exc:
+        return JSONResponse(
+            {"authenticated": False, "detail": str(exc)},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
     memberships = get_user_memberships(db, user.id)
     beta_admin = is_beta_access_admin(user.email) or bool(user.is_superadmin)
     return {
@@ -1074,7 +1084,10 @@ def search_memory_blocks_fulltext_endpoint(
                 x_forwarded_email=x_forwarded_email,
             )
             if email:
-                u = get_or_create_user(db, email=email, display_name=name)
+                u = get_or_create_user(
+                    db, email=email, display_name=name,
+                    external_subject=name, auth_provider="oauth2_proxy",
+                )
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,
@@ -1156,7 +1169,10 @@ def search_memory_blocks_semantic_endpoint(
             )
             current_user = None
             if email:
-                u = get_or_create_user(db, email=email, display_name=name)
+                u = get_or_create_user(
+                    db, email=email, display_name=name,
+                    external_subject=name, auth_provider="oauth2_proxy",
+                )
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,
@@ -1264,7 +1280,10 @@ def search_memory_blocks_hybrid_endpoint(
                 x_forwarded_email=x_forwarded_email,
             )
             if email:
-                u = get_or_create_user(db, email=email, display_name=name)
+                u = get_or_create_user(
+                    db, email=email, display_name=name,
+                    external_subject=name, auth_provider="oauth2_proxy",
+                )
                 memberships = get_user_memberships(db, u.id)
                 current_user = {
                     "id": u.id,

--- a/apps/hindsight-service/core/api/memory_blocks.py
+++ b/apps/hindsight-service/core/api/memory_blocks.py
@@ -27,6 +27,7 @@ from core.utils.scopes import (
 from core.api.deps import (
     get_current_user_context,
     get_current_user_context_or_pat,
+    get_or_create_user_for_request,
     ensure_pat_allows_write,
     ensure_pat_allows_read,
     get_scoped_user_and_context,
@@ -80,10 +81,7 @@ def _resolve_search_user_context(
     if not email:
         return None
 
-    user = get_or_create_user(
-        db, email=email, display_name=name,
-        external_subject=name, auth_provider="oauth2_proxy",
-    )
+    user = get_or_create_user_for_request(db, email=email, name=name)
     memberships = get_user_memberships(db, user.id)
     memberships_by_org = {str(m["organization_id"]): m for m in memberships}
     return {

--- a/apps/hindsight-service/core/api/memory_blocks.py
+++ b/apps/hindsight-service/core/api/memory_blocks.py
@@ -80,7 +80,10 @@ def _resolve_search_user_context(
     if not email:
         return None
 
-    user = get_or_create_user(db, email=email, display_name=name)
+    user = get_or_create_user(
+        db, email=email, display_name=name,
+        external_subject=name, auth_provider="oauth2_proxy",
+    )
     memberships = get_user_memberships(db, user.id)
     memberships_by_org = {str(m["organization_id"]): m for m in memberships}
     return {

--- a/apps/hindsight-service/core/async_bulk_operations.py
+++ b/apps/hindsight-service/core/async_bulk_operations.py
@@ -182,17 +182,26 @@ class BulkOperationTask:
             return await self._delete_keywords(db, org_id, errors)
         return 0
 
+    @staticmethod
+    def _destination_visibility_scope(dest_org_id, dest_owner_id) -> str:
+        # Org→org: stays organization. Org→personal (no dest_org): becomes personal.
+        # Without this, rows produce visibility_scope='organization' AND
+        # organization_id=NULL, which violates the ck_*_org_has_org constraints.
+        return "organization" if dest_org_id is not None else "personal"
+
     async def _move_agents(self, db: Session, org_id: uuid.UUID,
                           dest_org_id: Optional[uuid.UUID], dest_owner_id: Optional[uuid.UUID],
                           errors: list) -> int:
         """Move agents with proper error handling."""
         agents = db.query(models.Agent).filter(models.Agent.organization_id == org_id).all()
         moved_count = 0
+        new_scope = self._destination_visibility_scope(dest_org_id, dest_owner_id)
 
         for agent in agents:
             try:
                 agent.organization_id = dest_org_id
                 agent.owner_user_id = dest_owner_id
+                agent.visibility_scope = new_scope
                 db.commit()
                 moved_count += 1
             except (StaleDataError, ObjectDeletedError) as e:
@@ -201,7 +210,7 @@ class BulkOperationTask:
             except Exception as e:
                 db.rollback()
                 errors.append(f"Failed to move agent {agent.agent_id}: {e}")
-        
+
         return moved_count
 
     async def _move_memory_blocks(self, db: Session, org_id: uuid.UUID,
@@ -210,11 +219,13 @@ class BulkOperationTask:
         """Move memory blocks with proper error handling."""
         memory_blocks = db.query(models.MemoryBlock).filter(models.MemoryBlock.organization_id == org_id).all()
         moved_count = 0
+        new_scope = self._destination_visibility_scope(dest_org_id, dest_owner_id)
 
         for mb in memory_blocks:
             try:
                 mb.organization_id = dest_org_id
                 mb.owner_user_id = dest_owner_id
+                mb.visibility_scope = new_scope
                 db.commit()
                 moved_count += 1
             except (StaleDataError, ObjectDeletedError) as e:
@@ -223,7 +234,7 @@ class BulkOperationTask:
             except Exception as e:
                 db.rollback()
                 errors.append(f"Failed to move memory block {mb.id}: {e}")
-        
+
         return moved_count
 
     async def _move_keywords(self, db: Session, org_id: uuid.UUID,
@@ -232,11 +243,13 @@ class BulkOperationTask:
         """Move keywords with proper error handling."""
         keywords = db.query(models.Keyword).filter(models.Keyword.organization_id == org_id).all()
         moved_count = 0
+        new_scope = self._destination_visibility_scope(dest_org_id, dest_owner_id)
 
         for keyword in keywords:
             try:
                 keyword.organization_id = dest_org_id
                 keyword.owner_user_id = dest_owner_id
+                keyword.visibility_scope = new_scope
                 db.commit()
                 moved_count += 1
             except (StaleDataError, ObjectDeletedError) as e:
@@ -245,7 +258,7 @@ class BulkOperationTask:
             except Exception as e:
                 db.rollback()
                 errors.append(f"Failed to move keyword {keyword.keyword_id}: {e}")
-        
+
         return moved_count
 
     async def _delete_agents(self, db: Session, org_id: uuid.UUID, errors: list) -> int:

--- a/apps/hindsight-service/core/db/crud.py
+++ b/apps/hindsight-service/core/db/crud.py
@@ -518,6 +518,13 @@ def delete_consolidation_suggestion(db: Session, suggestion_id: uuid.UUID):
         return True
     return False
 
+class ConsolidationOriginalMismatchError(ValueError):
+    """Raised when a consolidation suggestion's originals do not share the
+    same (visibility_scope, owner_user_id, organization_id) tuple. Mixed
+    originals previously caused the new merged block to be minted under
+    `original_memory_ids[0].owner_user_id`, regardless of who validated."""
+
+
 def apply_consolidation(db: Session, suggestion_id: uuid.UUID):
     db_suggestion = db.query(models.ConsolidationSuggestion).filter(models.ConsolidationSuggestion.suggestion_id == suggestion_id).first()
     if db_suggestion and db_suggestion.status == 'pending':
@@ -537,7 +544,30 @@ def apply_consolidation(db: Session, suggestion_id: uuid.UUID):
                         continue
             if not norm_ids:
                 return None
-            first_memory_block = db.query(models.MemoryBlock).filter(models.MemoryBlock.id == norm_ids[0]).first()
+            originals = (
+                db.query(models.MemoryBlock)
+                .filter(models.MemoryBlock.id.in_(norm_ids))
+                .all()
+            )
+            if not originals:
+                return None
+            scope_keys = {
+                (
+                    getattr(o, 'visibility_scope', None),
+                    getattr(o, 'owner_user_id', None),
+                    getattr(o, 'organization_id', None),
+                )
+                for o in originals
+            }
+            if len(scope_keys) > 1:
+                raise ConsolidationOriginalMismatchError(
+                    f"Consolidation suggestion {suggestion_id} bundles memory blocks "
+                    f"with different (scope, owner, org) tuples: {scope_keys}."
+                )
+            first_memory_block = next(
+                (o for o in originals if o.id == norm_ids[0]),
+                originals[0],
+            )
             if first_memory_block:
                 new_memory_block = models.MemoryBlock(
                     agent_id=first_memory_block.agent_id,

--- a/apps/hindsight-service/core/db/repositories/memory_blocks.py
+++ b/apps/hindsight-service/core/db/repositories/memory_blocks.py
@@ -306,30 +306,7 @@ def retrieve_relevant_memories(
         payload.pop("search_type", None)
         payload.pop("rank_explanation", None)
         sanitized.append(schemas.MemoryBlock.model_validate(payload))
-    if sanitized:
-        return sanitized
-
-    # Legacy fallback to maintain behavior when search service filters return nothing
-    query = db.query(models.MemoryBlock)
-    if agent_id:
-        query = query.filter(models.MemoryBlock.agent_id == agent_id)
-    if conversation_id:
-        query = query.filter(models.MemoryBlock.conversation_id == conversation_id)
-
-    legacy_filters = []
-    for kw in normalized:
-        pattern = f"%{kw}%"
-        legacy_filters.append(models.MemoryBlock.content.ilike(pattern))
-        legacy_filters.append(models.MemoryBlock.errors.ilike(pattern))
-        legacy_filters.append(models.MemoryBlock.lessons_learned.ilike(pattern))
-    if legacy_filters:
-        query = query.filter(or_(*legacy_filters))
-
-    legacy_results = query.limit(limit).all()
-    return [
-        schemas.MemoryBlock.model_validate(result, from_attributes=True)
-        for result in legacy_results
-    ]
+    return sanitized
 
 
 def create_feedback_log(db: Session, feedback_log: schemas.FeedbackLogCreate):

--- a/apps/hindsight-service/core/db/scope_utils.py
+++ b/apps/hindsight-service/core/db/scope_utils.py
@@ -63,11 +63,21 @@ def apply_scope_filter(query, current_user: Optional[Dict[str, Any]], model_clas
     Returns:
         Filtered query
     """
+    # Defensive: a current_user dict that lacks an `id` would translate to
+    # `owner_user_id == NULL`, which matches every organization-scoped row
+    # (NULL owner is the canonical org-row signature) AND every public row.
+    # That would silently leak all org data. Treat it as "guest" so the
+    # caller gets public-only.
+    if current_user is not None:
+        try:
+            uid = current_user.get('id')
+        except Exception:
+            uid = None
+        if uid is None:
+            return query.filter(model_class.visibility_scope == SCOPE_PUBLIC)
+
     # Prepare unified OR conditions first so patched `or_` is always invoked in tests
-    try:
-        user_id = current_user.get('id') if current_user else None
-    except Exception:
-        user_id = None
+    user_id = current_user.get('id') if current_user else None
 
     org_ids = get_user_organization_ids(current_user) if current_user else []
 

--- a/apps/hindsight-service/core/services/search_service.py
+++ b/apps/hindsight-service/core/services/search_service.py
@@ -1132,13 +1132,8 @@ class SearchService:
         
         # Apply scope filters
         if current_user is None:
-            # Internal callers (e.g., agent tools) may not provide a user context but do
-            # pass an agent/conversation filter. In that case we retain historical
-            # behaviour and search across the agent's entire corpus regardless of
-            # visibility. Only default to public-only results when no scope hints are
-            # supplied.
-            if not agent_id and not conversation_id:
-                query = query.filter(models.MemoryBlock.visibility_scope == SCOPE_PUBLIC)
+            # Guests see public data only, regardless of agent_id/conversation_id hints.
+            query = query.filter(models.MemoryBlock.visibility_scope == SCOPE_PUBLIC)
         else:
             org_ids: List[uuid.UUID] = []
             for m in (current_user.get('memberships') or []):

--- a/apps/hindsight-service/core/services/search_service.py
+++ b/apps/hindsight-service/core/services/search_service.py
@@ -173,6 +173,40 @@ def _create_memory_block_with_score(
     return schemas.MemoryBlockWithScore(**memory_block_dict)
 
 
+def _apply_user_scope_filter(query, current_user, model_class):
+    """Apply visibility filter mirroring scope_utils.apply_scope_filter.
+
+    Treats `current_user is None` OR `current_user.get('id') is None` as a
+    guest: public-only. The latter case is critical — a malformed user dict
+    that lacks `id` would otherwise produce `owner_user_id == NULL`, which
+    matches every organization-scoped row (NULL owner is the canonical
+    org-row signature) and silently leaks all org data.
+    """
+    if current_user is None:
+        return query.filter(model_class.visibility_scope == SCOPE_PUBLIC)
+    user_id = current_user.get('id')
+    if user_id is None:
+        return query.filter(model_class.visibility_scope == SCOPE_PUBLIC)
+
+    org_ids: List[uuid.UUID] = []
+    for m in (current_user.get('memberships') or []):
+        try:
+            org_ids.append(uuid.UUID(m.get('organization_id')))
+        except Exception:
+            continue
+
+    return query.filter(
+        or_(
+            model_class.visibility_scope == SCOPE_PUBLIC,
+            model_class.owner_user_id == user_id,
+            and_(
+                model_class.visibility_scope == SCOPE_ORGANIZATION,
+                model_class.organization_id.in_(org_ids) if org_ids else False,
+            ),
+        )
+    )
+
+
 class SearchService:
     """Service for handling different types of memory block searches."""
     
@@ -245,26 +279,8 @@ class SearchService:
             )
 
             # Scope filters
-            if current_user is None:
-                base_query = base_query.filter(models.MemoryBlock.visibility_scope == SCOPE_PUBLIC)
-            else:
-                org_ids: List[uuid.UUID] = []
-                for m in (current_user.get('memberships') or []):
-                    try:
-                        org_ids.append(uuid.UUID(m.get('organization_id')))
-                    except Exception:
-                        pass
-                base_query = base_query.filter(
-                    or_(
-                        models.MemoryBlock.visibility_scope == SCOPE_PUBLIC,
-                        models.MemoryBlock.owner_user_id == current_user.get('id'),
-                        and_(
-                            models.MemoryBlock.visibility_scope == SCOPE_ORGANIZATION,
-                            models.MemoryBlock.organization_id.in_(org_ids) if org_ids else False,
-                        ),
-                    )
-                )
-            
+            base_query = _apply_user_scope_filter(base_query, current_user, models.MemoryBlock)
+
             # Apply filters
             if agent_id:
                 base_query = base_query.filter(models.MemoryBlock.agent_id == agent_id)
@@ -460,25 +476,7 @@ class SearchService:
         )
 
         # Scope filters (mirrors fulltext path)
-        if current_user is None:
-            base_query = base_query.filter(models.MemoryBlock.visibility_scope == SCOPE_PUBLIC)
-        else:
-            org_ids: List[uuid.UUID] = []
-            for membership in (current_user.get("memberships") or []):
-                try:
-                    org_ids.append(uuid.UUID(membership.get("organization_id")))
-                except Exception:
-                    continue
-            base_query = base_query.filter(
-                or_(
-                    models.MemoryBlock.visibility_scope == SCOPE_PUBLIC,
-                    models.MemoryBlock.owner_user_id == current_user.get("id"),
-                    and_(
-                        models.MemoryBlock.visibility_scope == SCOPE_ORGANIZATION,
-                        models.MemoryBlock.organization_id.in_(org_ids) if org_ids else False,
-                    ),
-                )
-            )
+        base_query = _apply_user_scope_filter(base_query, current_user, models.MemoryBlock)
 
         if agent_id:
             base_query = base_query.filter(models.MemoryBlock.agent_id == agent_id)
@@ -1130,27 +1128,8 @@ class SearchService:
         if combined_filter is not None:
             query = query.filter(combined_filter)
         
-        # Apply scope filters
-        if current_user is None:
-            # Guests see public data only, regardless of agent_id/conversation_id hints.
-            query = query.filter(models.MemoryBlock.visibility_scope == SCOPE_PUBLIC)
-        else:
-            org_ids: List[uuid.UUID] = []
-            for m in (current_user.get('memberships') or []):
-                try:
-                    org_ids.append(uuid.UUID(m.get('organization_id')))
-                except Exception:
-                    pass
-            query = query.filter(
-                or_(
-                    models.MemoryBlock.visibility_scope == SCOPE_PUBLIC,
-                    models.MemoryBlock.owner_user_id == current_user.get('id'),
-                    and_(
-                        models.MemoryBlock.visibility_scope == SCOPE_ORGANIZATION,
-                        models.MemoryBlock.organization_id.in_(org_ids) if org_ids else False,
-                    ),
-                )
-            )
+        # Apply scope filters; guests (and malformed dicts without `id`) see public only.
+        query = _apply_user_scope_filter(query, current_user, models.MemoryBlock)
 
         # Apply additional filters
         if agent_id:

--- a/apps/hindsight-service/migrations/versions/2026042900_users_external_subject_unique.py
+++ b/apps/hindsight-service/migrations/versions/2026042900_users_external_subject_unique.py
@@ -1,0 +1,39 @@
+"""Add a partial unique index on users.external_subject.
+
+`auth.get_or_create_user` binds a user row's external_subject on first
+authenticated sign-in (TOFU). Without a uniqueness guarantee, two
+concurrent first-time logins for the same email could both pass the
+"existing_sub is NULL" branch, both write a value, and the loser's row
+state would be overwritten silently — locking out one of them. We
+enforce uniqueness in the DB so the second writer fails cleanly and the
+first writer wins.
+
+Use a partial index (WHERE external_subject IS NOT NULL) so legacy
+rows with NULL external_subject keep working. Once the column is fully
+populated (after every active user has signed in once post-fix), the
+partial constraint can be tightened.
+
+Revision ID: 2026042900
+Revises: 8c0f1b2d4a6b
+"""
+from alembic import op
+
+
+revision = "2026042900"
+down_revision = "8c0f1b2d4a6b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_users_external_subject
+        ON users (external_subject)
+        WHERE external_subject IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_users_external_subject")

--- a/apps/hindsight-service/scripts/rebind_user_subject.py
+++ b/apps/hindsight-service/scripts/rebind_user_subject.py
@@ -1,0 +1,100 @@
+"""
+Operator script to clear or rebind a User row's external_subject.
+
+Use cases:
+  - The deployment's oauth2-proxy `--user-id-claim` was changed (e.g.
+    preferred_username -> sub) and existing users now hit
+    IdentityMismatchError on every sign-in.
+  - A real account-recovery situation where a user's Google sub
+    legitimately changed (rare; provider migration).
+  - Cleanup after a failed F2 partial deployment.
+
+Usage:
+    python -m scripts.rebind_user_subject --email user@example.com --clear
+    python -m scripts.rebind_user_subject --email user@example.com \\
+        --new-subject 1234567890
+
+Always lists the affected row and prompts before committing unless
+--yes is passed.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def _engine():
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL not set", file=sys.stderr)
+        sys.exit(2)
+    return create_engine(url, future=True)
+
+
+def _confirm(prompt: str, *, yes: bool) -> bool:
+    if yes:
+        return True
+    answer = input(f"{prompt} [y/N] ").strip().lower()
+    return answer in ("y", "yes")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--email", required=True, help="User email (case-insensitive)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--clear", action="store_true", help="Set external_subject and auth_provider to NULL")
+    group.add_argument("--new-subject", help="Set external_subject to this value")
+    parser.add_argument("--auth-provider", default=None, help="Optional: set auth_provider alongside --new-subject")
+    parser.add_argument("--yes", action="store_true", help="Don't prompt")
+    args = parser.parse_args()
+
+    engine = _engine()
+    Session = sessionmaker(bind=engine, future=True)
+    from core.db import models
+
+    with Session() as session:
+        user = (
+            session.query(models.User)
+            .filter(models.User.email == args.email.strip().lower())
+            .first()
+        )
+        if not user:
+            print(f"No user found with email {args.email!r}", file=sys.stderr)
+            return 1
+        print(
+            f"Current state: id={user.id} email={user.email} "
+            f"external_subject={user.external_subject!r} "
+            f"auth_provider={user.auth_provider!r}"
+        )
+        if args.clear:
+            if not _confirm("Clear external_subject and auth_provider?", yes=args.yes):
+                print("Aborted.")
+                return 1
+            user.external_subject = None
+            user.auth_provider = None
+        else:
+            new_sub: Optional[str] = args.new_subject
+            if not _confirm(f"Set external_subject={new_sub!r}?", yes=args.yes):
+                print("Aborted.")
+                return 1
+            user.external_subject = new_sub
+            if args.auth_provider is not None:
+                user.auth_provider = args.auth_provider
+
+        session.commit()
+        session.refresh(user)
+        print(
+            f"New state: id={user.id} email={user.email} "
+            f"external_subject={user.external_subject!r} "
+            f"auth_provider={user.auth_provider!r}"
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -444,11 +444,11 @@ def test_B_bulk_move_api_accepts_arbitrary_destination_owner_dry_run(db_session)
 # ---------------------------------------------------------------------------
 
 
-def test_F6_bulk_delete_dry_run_leaks_counts_to_non_member(db_session):
+def test_F6_bulk_delete_dry_run_rejects_non_member(db_session):
     """
-    `bulk_operations.py:262-298` lets any authenticated user submit a delete
-    plan against any organization and learn agent_count / memory_block_count /
-    keyword_count. A small information disclosure, included for completeness.
+    Regression guard for F6: bulk-delete dry-run must require source-org
+    membership, matching bulk-move dry-run. Otherwise it discloses
+    per-resource counts (agents / memory_blocks / keywords) to outsiders.
     """
     h_admin = _h("orgadmin-f6", scope="personal")
     h_outsider = _h("outsider-f6", scope="personal")
@@ -462,21 +462,25 @@ def test_F6_bulk_delete_dry_run_leaks_counts_to_non_member(db_session):
     assert r_org.status_code == 201, r_org.text
     org_id = r_org.json()["id"]
 
-    # Outsider (not a member) requests dry-run delete plan and gets a 200 with counts.
+    # Outsider (not a member) is rejected.
     r = client.post(
         f"/bulk-operations/organizations/{org_id}/bulk-delete",
         json={"dry_run": True, "resource_types": ["memory_blocks", "agents", "keywords"]},
         headers=h_outsider,
     )
-    assert r.status_code == 200, (
-        f"BUG NOT REPRODUCED: outsider was rejected by bulk-delete dry-run "
-        f"(status={r.status_code}): {r.text}"
+    assert r.status_code == 403, (
+        f"REGRESSION (F6): outsider got {r.status_code} from bulk-delete dry-run; "
+        f"expected 403. Body: {r.text}"
     )
-    body = r.json()
-    assert "resources_to_delete" in body
-    assert "memory_blocks" in body["resources_to_delete"]
-    assert "agents" in body["resources_to_delete"]
-    assert "keywords" in body["resources_to_delete"]
+
+    # Member of the org still gets the plan (positive case).
+    r2 = client.post(
+        f"/bulk-operations/organizations/{org_id}/bulk-delete",
+        json={"dry_run": True, "resource_types": ["memory_blocks", "agents", "keywords"]},
+        headers=h_admin,
+    )
+    assert r2.status_code == 200, r2.text
+    assert "resources_to_delete" in r2.json()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -576,6 +576,32 @@ def test_F6_bulk_delete_dry_run_rejects_non_member(db_session):
     assert "resources_to_delete" in r2.json()
 
 
+def test_change_scope_non_superadmin_cannot_set_new_owner_user_id(db_session):
+    """
+    Single-block sibling of the B fix: `change_memory_block_scope` (in
+    main.py) accepts a `new_owner_user_id` but only a superadmin may use it.
+    Confirm the guard fires for a non-superadmin.
+    """
+    h_alice = _h("alice-changescope")
+    h_bob = _h("bob-changescope")
+    client_alice = _client()
+    client_bob = _client()
+
+    bob_id = client_bob.get("/user-info", headers=h_bob).json()["user_id"]
+    mb = _create_personal_memory(client_alice, h_alice, f"CS_{uuid.uuid4().hex}")
+
+    # Alice is not superadmin; she cannot redirect a personal block to bob.
+    r = client_alice.post(
+        f"/memory-blocks/{mb['id']}/change-scope",
+        json={"visibility_scope": "personal", "new_owner_user_id": bob_id},
+        headers=h_alice,
+    )
+    assert r.status_code == 403, (
+        f"REGRESSION: non-superadmin was allowed to set new_owner_user_id. "
+        f"Status={r.status_code}: {r.text}"
+    )
+
+
 def test_E_apply_scope_filter_treats_id_less_user_as_guest(db_session):
     """
     Regression guard for E: a malformed `current_user` dict that lacks an

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -488,25 +488,39 @@ def test_F6_bulk_delete_dry_run_rejects_non_member(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_D_user_info_localhost_host_fallback_returns_dev_user(db_session, monkeypatch):
+def test_D_user_info_no_longer_spoofable_via_host_header(db_session, monkeypatch):
     """
-    `core/api/main.py:361-387`: when no auth headers and no PAT are present,
-    if Host starts with 'localhost' OR client_ip is in (127.0.0.1, ::1, None),
-    `/user-info` returns the dev user `dev@localhost` with full memberships.
+    Regression guard for D: the local-dev fallback in /user-info must NOT
+    fire purely because the Host header starts with 'localhost'. Production
+    safety previously relied entirely on Traefik filtering Host; any direct
+    backend access (port-forward, debug, internal) bypassed it.
 
-    TestClient sets `host = testserver` by default, so we override it.
+    We assert two cases:
+      1. ALLOW_LOCAL_DEV_AUTH=true + spoofed Host: localhost.* → 401 unauth
+         (because client_ip from TestClient is 'testclient', not loopback)
+      2. ALLOW_LOCAL_DEV_AUTH unset → default off → 401 unauth
     """
-    monkeypatch.setenv("ALLOW_LOCAL_DEV_AUTH", "true")
-    # Make sure DEV_MODE itself is OFF so we hit the local-dev fallback branch,
-    # not the dev-mode branch.
     monkeypatch.delenv("DEV_MODE", raising=False)
 
+    # Case 1: env explicitly opts in, but client_ip is not loopback.
+    monkeypatch.setenv("ALLOW_LOCAL_DEV_AUTH", "true")
     client = _guest_client()
     r = client.get("/user-info", headers={"host": "localhost.evil.example.com"})
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert body.get("authenticated") is True, (
-        f"BUG NOT REPRODUCED: localhost-host fallback did not authenticate the request. "
-        f"Body: {body}"
-    )
-    assert body.get("email") == "dev@localhost"
+    assert r.status_code in (401, 200), r.text
+    if r.status_code == 200:
+        # If the endpoint still returns 200 it must be the unauthenticated marker, not a dev user.
+        body = r.json()
+        assert body.get("authenticated") is not True, (
+            f"REGRESSION (D): Host-header spoof produced an authenticated response: {body}"
+        )
+        assert body.get("email") != "dev@localhost"
+
+    # Case 2: env unset → default off.
+    monkeypatch.delenv("ALLOW_LOCAL_DEV_AUTH", raising=False)
+    client2 = _guest_client()
+    r2 = client2.get("/user-info", headers={"host": "localhost.evil.example.com"})
+    assert r2.status_code in (401, 200), r2.text
+    if r2.status_code == 200:
+        body2 = r2.json()
+        assert body2.get("authenticated") is not True
+        assert body2.get("email") != "dev@localhost"

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -314,36 +314,27 @@ def test_A_consolidation_validate_minted_under_first_id_owner(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_B_bulk_move_executor_does_not_update_visibility_scope(db_session):
+def test_B_bulk_move_executor_now_updates_visibility_scope(db_session):
     """
-    `core/async_bulk_operations.py:_move_memory_blocks` (lines 207-227) sets
-    `organization_id = dest_org_id` and `owner_user_id = dest_owner_id` but
-    *does not* update `visibility_scope`. For org→personal moves this produces
-    a row with `visibility_scope='organization'` AND `organization_id=NULL`,
-    which violates the `ck_memory_blocks_org_has_org` check constraint.
-
-    The DB constraint is therefore the *only* thing preventing this code path
-    from silently dropping organization data into a non-member's personal scope.
-    If the constraint is ever relaxed or the executor is patched without also
-    fixing the dest_owner validation, the leak becomes real.
-
-    To avoid SQLAlchemy session-state issues with the conftest's transactional
-    rollback, we exercise the executor's two write statements via a fresh
-    short-lived session. This isolates the IntegrityError to its own session
-    while the suite's outer rollback still cleans up.
+    Regression guard for B (executor half): `_move_memory_blocks` must set
+    `visibility_scope` to a value consistent with the new (organization_id,
+    owner_user_id). Without that update, org→personal moves produced rows
+    that violated `ck_memory_blocks_org_has_org`, and the DB constraint was
+    the only line of defense.
     """
-    from sqlalchemy.exc import IntegrityError
+    import asyncio
     from sqlalchemy.orm import sessionmaker
 
-    h_admin = _h("orgadmin-b", scope="personal")
-    h_carol = _h("carol-b", scope="personal")
+    from core.async_bulk_operations import BulkOperationTask
+
+    h_admin = _h("orgadmin-bx", scope="personal")
     client = _client()
-    carol_info = client.get("/user-info", headers=h_carol).json()
-    carol_id = uuid.UUID(carol_info["user_id"])
+    admin_info = client.get("/user-info", headers=h_admin).json()
+    admin_id = uuid.UUID(admin_info["user_id"])
 
     r_org = client.post(
         "/organizations/",
-        json={"name": "Org B", "slug": f"org-b-{uuid.uuid4().hex[:8]}"},
+        json={"name": "Org Bx", "slug": f"org-bx-{uuid.uuid4().hex[:8]}"},
         headers=h_admin,
     )
     assert r_org.status_code == 201, r_org.text
@@ -356,13 +347,12 @@ def test_B_bulk_move_executor_does_not_update_visibility_scope(db_session):
         headers=h_admin_org,
     )
     agent_id = r_agent.json()["agent_id"]
-
     r_mb = client.post(
         "/memory-blocks/",
         json={
             "agent_id": agent_id,
             "conversation_id": str(uuid.uuid4()),
-            "content": f"ORG_DATA_LEAK_{uuid.uuid4().hex}",
+            "content": f"ORG_BX_{uuid.uuid4().hex}",
             "visibility_scope": "organization",
             "organization_id": str(org_id),
         },
@@ -371,48 +361,57 @@ def test_B_bulk_move_executor_does_not_update_visibility_scope(db_session):
     assert r_mb.status_code == 201, r_mb.text
     mb_id = uuid.UUID(r_mb.json()["id"])
 
-    # Reproduce the executor's exact write logic in a fresh session to avoid
-    # poisoning the conftest session.
+    # Run the executor in a fresh session to avoid the conftest's transactional
+    # session getting in the way of asyncio commits.
     bind = db_session.get_bind()
     LocalSession = sessionmaker(bind=bind, autoflush=False, autocommit=False)
     s2 = LocalSession()
     try:
-        mb = s2.query(models.MemoryBlock).filter(models.MemoryBlock.id == mb_id).first()
-        assert mb is not None, "Memory block should be visible from the fresh session."
-        # NOTE: the executor does NOT touch visibility_scope. Mirror that.
-        mb.organization_id = None
-        mb.owner_user_id = carol_id
-        leaked_silently = False
-        try:
-            s2.commit()
-            leaked_silently = True
-        except IntegrityError as e:
-            s2.rollback()
-            assert "ck_memory_blocks_org_has_org" in str(e), (
-                f"Expected the org-has-org check constraint to fire; got: {e}"
-            )
-        assert not leaked_silently, (
-            "REGRESSION: the executor's UPDATE was accepted by the DB. The "
-            "ck_memory_blocks_org_has_org constraint that currently saves us "
-            "has been weakened/removed, and `_move_memory_blocks` is missing "
-            "both (a) destination_owner_user_id validation and (b) a "
-            "visibility_scope update. This is now an exploitable silent leak."
+        task = BulkOperationTask(
+            operation_id=uuid.uuid4(),
+            task_type="bulk_move",
+            actor_user_id=admin_id,
+            organization_id=org_id,
+            payload={},
         )
+        errors: list = []
+        moved = asyncio.run(
+            task._move_memory_blocks(
+                db=s2,
+                org_id=org_id,
+                dest_org_id=None,
+                dest_owner_id=admin_id,  # admin moves the org's data to their own personal scope
+                errors=errors,
+            )
+        )
+        assert errors == [], f"Move errors: {errors}"
+        assert moved == 1
     finally:
         s2.close()
 
+    db_session.expire_all()
+    mb = db_session.query(models.MemoryBlock).filter(models.MemoryBlock.id == mb_id).first()
+    assert mb is not None
+    assert mb.visibility_scope == "personal", (
+        f"Executor must update visibility_scope to 'personal' on org→personal moves; got {mb.visibility_scope}"
+    )
+    assert str(mb.owner_user_id) == str(admin_id)
+    assert mb.organization_id is None
 
-def test_B_bulk_move_api_accepts_arbitrary_destination_owner_dry_run(db_session):
+
+def test_B_bulk_move_api_rejects_destination_owner_other_than_actor(db_session):
     """
-    Independent reproduction at the API layer: the bulk-move dry-run path runs
-    synchronously and is allowed even when destination_owner_user_id is a
-    user the actor has no relationship with. This proves the *authorisation*
-    half of the bug — the recipient's identity is never validated.
+    Regression guard for B (auth half): a non-superadmin must not be able to
+    set destination_owner_user_id to anyone but themselves. This blocks the
+    "org admin dumps org data into a stranger's personal scope" path.
+    Moving to the actor's own personal scope is still allowed.
     """
     h_admin = _h("orgadmin-b2", scope="personal")
     h_carol = _h("carol-b2", scope="personal")
     client = _client()
+    admin_info = client.get("/user-info", headers=h_admin).json()
     carol_info = client.get("/user-info", headers=h_carol).json()
+    admin_id = admin_info["user_id"]
     carol_id = carol_info["user_id"]
 
     r_org = client.post(
@@ -423,7 +422,7 @@ def test_B_bulk_move_api_accepts_arbitrary_destination_owner_dry_run(db_session)
     assert r_org.status_code == 201, r_org.text
     org_id = r_org.json()["id"]
 
-    # Dry-run accepts arbitrary recipient with no relationship to actor or org.
+    # Negative case: arbitrary recipient (carol) is rejected.
     r = client.post(
         f"/bulk-operations/organizations/{org_id}/bulk-move",
         json={
@@ -433,10 +432,22 @@ def test_B_bulk_move_api_accepts_arbitrary_destination_owner_dry_run(db_session)
         },
         headers=h_admin,
     )
-    assert r.status_code == 200, (
-        f"BUG NOT REPRODUCED: bulk-move dry-run with arbitrary destination_owner_user_id "
-        f"was rejected (status={r.status_code}): {r.text}"
+    assert r.status_code == 403, (
+        f"REGRESSION (B): non-superadmin admin was permitted to set "
+        f"destination_owner_user_id to a third-party user. Status={r.status_code}: {r.text}"
     )
+
+    # Positive case: actor moves to their own personal scope.
+    r2 = client.post(
+        f"/bulk-operations/organizations/{org_id}/bulk-move",
+        json={
+            "destination_owner_user_id": admin_id,
+            "resource_types": ["memory_blocks"],
+            "dry_run": True,
+        },
+        headers=h_admin,
+    )
+    assert r2.status_code == 200, r2.text
 
 
 # ---------------------------------------------------------------------------

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -500,6 +500,54 @@ def test_F6_bulk_delete_dry_run_rejects_non_member(db_session):
     assert "resources_to_delete" in r2.json()
 
 
+def test_E_apply_scope_filter_treats_id_less_user_as_guest(db_session):
+    """
+    Regression guard for E: a malformed `current_user` dict that lacks an
+    `id` key must not produce `owner_user_id IS NULL`, which would match
+    every organization-scoped row (NULL owner is the canonical org-row
+    signature) and silently leak all org data.
+    """
+    from core.db import models, scope_utils
+    from core.services.search_service import _apply_user_scope_filter
+
+    # Seed: one personal block with explicit owner, one org block with NULL owner.
+    user = models.User(email=f"e_user_{uuid.uuid4().hex}@ex.com", display_name="E", is_superadmin=False)
+    db_session.add(user); db_session.commit(); db_session.refresh(user)
+    agent_p = models.Agent(agent_name=f"E-agent-{uuid.uuid4().hex[:6]}", visibility_scope="personal", owner_user_id=user.id)
+    db_session.add(agent_p); db_session.commit(); db_session.refresh(agent_p)
+    org = models.Organization(name=f"E-org-{uuid.uuid4().hex[:6]}", slug=f"e-org-{uuid.uuid4().hex[:6]}", created_by=user.id)
+    db_session.add(org); db_session.commit(); db_session.refresh(org)
+    agent_o = models.Agent(agent_name=f"E-org-agent-{uuid.uuid4().hex[:6]}", visibility_scope="organization", organization_id=org.id)
+    db_session.add(agent_o); db_session.commit(); db_session.refresh(agent_o)
+
+    mb_personal = models.MemoryBlock(agent_id=agent_p.agent_id, conversation_id=uuid.uuid4(), content="E_PERSONAL", visibility_scope="personal", owner_user_id=user.id)
+    mb_org = models.MemoryBlock(agent_id=agent_o.agent_id, conversation_id=uuid.uuid4(), content="E_ORG", visibility_scope="organization", organization_id=org.id)
+    db_session.add_all([mb_personal, mb_org]); db_session.commit()
+
+    malformed_ctx = {}  # truthy dict, no 'id' — the dangerous shape.
+
+    # scope_utils.apply_scope_filter must treat the malformed dict as a guest.
+    q1 = scope_utils.apply_scope_filter(db_session.query(models.MemoryBlock), malformed_ctx, models.MemoryBlock)
+    rows1 = q1.all()
+    org_rows_1 = [r for r in rows1 if r.visibility_scope == "organization"]
+    personal_rows_1 = [r for r in rows1 if r.visibility_scope == "personal"]
+    assert org_rows_1 == [], (
+        f"REGRESSION (E): scope_utils.apply_scope_filter leaked {len(org_rows_1)} org rows to a "
+        f"malformed user_ctx (no 'id')."
+    )
+    assert personal_rows_1 == [], (
+        f"REGRESSION (E): scope_utils.apply_scope_filter leaked {len(personal_rows_1)} personal rows."
+    )
+
+    # search_service._apply_user_scope_filter same invariant.
+    q2 = _apply_user_scope_filter(db_session.query(models.MemoryBlock), malformed_ctx, models.MemoryBlock)
+    rows2 = q2.all()
+    assert all(r.visibility_scope == "public" for r in rows2), (
+        f"REGRESSION (E): search_service._apply_user_scope_filter returned non-public rows for a "
+        f"malformed user_ctx: {[(r.id, r.visibility_scope) for r in rows2]}"
+    )
+
+
 def test_bulk_move_dry_run_requires_source_org_membership(db_session):
     """
     Regression guard for the asymmetry that the F6 fix surfaced: bulk_move's

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -23,8 +23,10 @@ rollback handles teardown.
 import os
 import uuid
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 
 from core.api.main import app as main_app
 from core.db import models
@@ -57,6 +59,19 @@ def _client(extra_headers: dict | None = None) -> TestClient:
 def _guest_client() -> TestClient:
     """A TestClient that sends no auth headers and no default scope header."""
     return TestClient(main_app)
+
+
+def _async_client_with_loopback_ip() -> httpx.AsyncClient:
+    """An httpx.AsyncClient that drives the FastAPI app via ASGITransport,
+    with the request scope's `client` set to ('127.0.0.1', 50000). Needed
+    to exercise the legitimate local-dev fallback path in /user-info,
+    which checks `request.client.host in ('127.0.0.1', '::1')`. The
+    default TestClient yields `client=('testclient', 50000)` and would
+    never satisfy the check. ASGITransport is async-only in httpx 0.28+,
+    so the test using this helper must be async.
+    """
+    transport = ASGITransport(app=main_app, client=("127.0.0.1", 50000))
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
 
 
 def _create_personal_memory(client: TestClient, headers: dict, content: str, agent_name: str | None = None) -> dict:
@@ -158,6 +173,23 @@ def test_F2_email_recycle_attempt_is_rejected(db_session):
     rows = db_session.query(models.User).filter(models.User.email == email).all()
     assert len(rows) == 1, f"Expected 1 User row for {email}, found {len(rows)}"
     assert rows[0].external_subject == "Alice First"
+
+    # Validate the global IdentityMismatchError handler also catches the
+    # search-endpoint path (which previously surfaced the error as 500).
+    r_search = client_second.get(
+        "/memory-blocks/search/",
+        params={"keywords": "anything", "search_type": "fulltext"},
+        headers={
+            "x-auth-request-user": "Alice Second",
+            "x-auth-request-email": email,
+        },
+    )
+    assert r_search.status_code == 401, (
+        f"REGRESSION (F2 handler): mismatched second sign-in via /search/ "
+        f"returned {r_search.status_code} instead of 401. The global "
+        f"IdentityMismatchError exception handler is missing or scoped "
+        f"too narrowly. Body: {r_search.text}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -264,16 +296,15 @@ def test_A_consolidation_validate_rejects_cross_owner_suggestion(db_session):
     db_session.commit()
     suggestion_id = str(suggestion.suggestion_id)
 
-    # Alice attempts to validate — she lacks write access on bob's original AND
-    # the originals span owners. Either the 403 (write-on-every-original) or
-    # the 409 (cross-owner) check should reject; the bug previously returned 200.
+    # Alice attempts to validate — she lacks write access on bob's original.
+    # The write check fires before the cross-owner check, so this MUST be 403.
     r = client_alice.post(
         f"/consolidation-suggestions/{suggestion_id}/validate/",
         headers=h_alice,
     )
-    assert r.status_code in (403, 409), (
-        f"REGRESSION (A): cross-owner validation returned {r.status_code}. "
-        f"Body: {r.text}"
+    assert r.status_code == 403, (
+        f"REGRESSION (A write check): alice has no write access on bob's block; "
+        f"expected 403, got {r.status_code}. Body: {r.text}"
     )
 
     # No merged block was created and no original was archived.
@@ -310,6 +341,51 @@ def test_A_consolidation_validate_rejects_cross_owner_suggestion(db_session):
         headers=h_alice,
     )
     assert r2.status_code == 200, r2.text
+
+
+def test_A_consolidation_superadmin_cross_owner_returns_409(db_session):
+    """
+    Regression guard for A's cross-owner check at the apply layer. When the
+    actor IS a superadmin (so `_user_can_write_suggestion` passes), the
+    cross-owner refusal in apply_consolidation must still fire. The 409
+    path is what proves the apply-layer invariant is active; the 403 path
+    in test_A_consolidation_validate_rejects_cross_owner_suggestion only
+    proves the write-check exists.
+    """
+    h_alice = _h("alice-admin-A409")
+    h_bob = _h("bob-A409")
+    client_alice = _client()
+    client_bob = _client()
+
+    mb_alice = _create_personal_memory(client_alice, h_alice, f"ALICE_{uuid.uuid4().hex}")
+    mb_bob = _create_personal_memory(client_bob, h_bob, f"BOB_{uuid.uuid4().hex}")
+
+    # Promote alice to superadmin via DB so the write check passes.
+    alice_id = client_alice.get("/user-info", headers=h_alice).json()["user_id"]
+    alice_row = db_session.query(models.User).filter(models.User.id == uuid.UUID(alice_id)).one()
+    alice_row.is_superadmin = True
+    db_session.commit()
+
+    suggestion = models.ConsolidationSuggestion(
+        group_id=uuid.uuid4(),
+        suggested_content=f"MERGED_409_{uuid.uuid4().hex}",
+        suggested_lessons_learned="MERGED_LESSONS",
+        suggested_keywords=["alpha"],
+        original_memory_ids=[mb_bob["id"], mb_alice["id"]],
+        status="pending",
+    )
+    db_session.add(suggestion)
+    db_session.commit()
+
+    r = client_alice.post(
+        f"/consolidation-suggestions/{suggestion.suggestion_id}/validate/",
+        headers=h_alice,
+    )
+    assert r.status_code == 409, (
+        f"REGRESSION (A apply-layer): superadmin validation of a cross-owner "
+        f"suggestion should still hit the apply-time invariant and return 409, "
+        f"got {r.status_code}. Body: {r.text}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -599,39 +675,56 @@ def test_bulk_move_dry_run_requires_source_org_membership(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_D_user_info_no_longer_spoofable_via_host_header(db_session, monkeypatch):
+def test_D_host_header_spoof_does_not_grant_dev_user(db_session, monkeypatch):
     """
-    Regression guard for D: the local-dev fallback in /user-info must NOT
-    fire purely because the Host header starts with 'localhost'. Production
-    safety previously relied entirely on Traefik filtering Host; any direct
-    backend access (port-forward, debug, internal) bypassed it.
-
-    We assert two cases:
-      1. ALLOW_LOCAL_DEV_AUTH=true + spoofed Host: localhost.* → 401 unauth
-         (because client_ip from TestClient is 'testclient', not loopback)
-      2. ALLOW_LOCAL_DEV_AUTH unset → default off → 401 unauth
+    Regression guard for D (negative case): a non-loopback caller sending
+    `Host: localhost.*` plus `ALLOW_LOCAL_DEV_AUTH=true` and no auth
+    headers must not get the dev user. Pre-fix, `host.startswith('localhost')`
+    was sufficient to mint a `dev@localhost` superadmin context regardless of
+    the actual peer.
     """
     monkeypatch.delenv("DEV_MODE", raising=False)
-
-    # Case 1: env explicitly opts in, but client_ip is not loopback.
     monkeypatch.setenv("ALLOW_LOCAL_DEV_AUTH", "true")
-    client = _guest_client()
-    r = client.get("/user-info", headers={"host": "localhost.evil.example.com"})
-    assert r.status_code in (401, 200), r.text
-    if r.status_code == 200:
-        # If the endpoint still returns 200 it must be the unauthenticated marker, not a dev user.
-        body = r.json()
-        assert body.get("authenticated") is not True, (
-            f"REGRESSION (D): Host-header spoof produced an authenticated response: {body}"
-        )
-        assert body.get("email") != "dev@localhost"
 
-    # Case 2: env unset → default off.
+    client = _guest_client()  # client_ip = 'testclient'
+    r = client.get("/user-info", headers={"host": "localhost.evil.example.com"})
+    assert r.status_code == 401, (
+        f"REGRESSION (D): host-header spoof from non-loopback peer "
+        f"returned {r.status_code} instead of 401. Body: {r.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_D_default_off_blocks_loopback_when_env_unset(db_session, monkeypatch):
+    """
+    Regression guard for D's env default: with ALLOW_LOCAL_DEV_AUTH unset,
+    even a real loopback caller must NOT get the dev fallback.
+    """
+    monkeypatch.delenv("DEV_MODE", raising=False)
     monkeypatch.delenv("ALLOW_LOCAL_DEV_AUTH", raising=False)
-    client2 = _guest_client()
-    r2 = client2.get("/user-info", headers={"host": "localhost.evil.example.com"})
-    assert r2.status_code in (401, 200), r2.text
-    if r2.status_code == 200:
-        body2 = r2.json()
-        assert body2.get("authenticated") is not True
-        assert body2.get("email") != "dev@localhost"
+
+    async with _async_client_with_loopback_ip() as client:
+        r = await client.get("/user-info")
+        assert r.status_code == 401, (
+            f"REGRESSION (D): default-off was bypassed even from loopback. "
+            f"Status={r.status_code} body={r.text}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_D_loopback_with_env_on_still_works(db_session, monkeypatch):
+    """
+    Positive case for D: when ALLOW_LOCAL_DEV_AUTH=true AND the peer is
+    actually loopback (real local-dev workflow), the fallback must still
+    produce the dev user. Without this case, an over-tight fix that
+    accidentally broke the legitimate local-dev path would go unnoticed.
+    """
+    monkeypatch.delenv("DEV_MODE", raising=False)
+    monkeypatch.setenv("ALLOW_LOCAL_DEV_AUTH", "true")
+
+    async with _async_client_with_loopback_ip() as client:
+        r = await client.get("/user-info")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body.get("authenticated") is True
+        assert body.get("email") == os.getenv("DEV_LOCAL_EMAIL", "dev@localhost")

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -156,12 +156,13 @@ def test_F2_email_collision_grants_account_takeover(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_F1_guest_basic_search_with_agent_id_returns_personal_data(db_session):
+def test_F1_guest_basic_search_with_agent_id_does_not_leak_personal_data(db_session):
     """
-    Per `core/services/search_service.py:1133-1141`, when current_user is None
-    AND agent_id (or conversation_id) is supplied, no visibility filter is
-    applied. A guest hitting /memory-blocks/search/?search_type=basic with a
-    known agent_id therefore receives personal memory blocks.
+    Regression guard for F1: `_basic_search_fallback` must apply the public-only
+    filter for guest callers regardless of whether `agent_id` or
+    `conversation_id` is supplied. The previous carve-out treated those as a
+    permission grant, which let any anonymous caller read personal memory
+    blocks for a known agent.
     """
     secret_content = f"PERSONAL_LEAK_TARGET_{uuid.uuid4().hex}"
     h_alice = _h("alice-leak-target")
@@ -182,14 +183,12 @@ def test_F1_guest_basic_search_with_agent_id_returns_personal_data(db_session):
     )
     assert r.status_code == 200, r.text
     contents = [item["content"] for item in r.json()]
-    assert secret_content in contents, (
-        "BUG NOT REPRODUCED: guest with agent_id should have received the personal "
-        "memory block, but did not. Either the carve-out at search_service.py:1133-1141 "
-        "is gone or the call path no longer reaches it."
+    assert secret_content not in contents, (
+        "REGRESSION (F1): guest with agent_id received a personal memory block. "
+        "_basic_search_fallback must not honor agent_id as a permission grant."
     )
 
-    # Sanity: same call WITHOUT agent_id should fall back to the public-only
-    # branch and return nothing for this personal block.
+    # Same call without agent_id was the previously-correct branch and must stay safe.
     r2 = guest.get(
         "/memory-blocks/search/",
         params={
@@ -199,9 +198,22 @@ def test_F1_guest_basic_search_with_agent_id_returns_personal_data(db_session):
         },
     )
     assert r2.status_code == 200, r2.text
-    contents2 = [item["content"] for item in r2.json()]
-    assert secret_content not in contents2, (
-        "Sanity check failed: the no-agent_id guest branch should be public-only."
+    assert secret_content not in [item["content"] for item in r2.json()]
+
+    # Authenticated user reading their own data through the same path still works.
+    r3 = client_authed.get(
+        "/memory-blocks/search/",
+        params={
+            "keywords": "PERSONAL_LEAK_TARGET",
+            "agent_id": agent_id,
+            "search_type": "basic",
+            "limit": 50,
+        },
+        headers=h_alice,
+    )
+    assert r3.status_code == 200, r3.text
+    assert secret_content in [item["content"] for item in r3.json()], (
+        "Owner should still be able to find their own memory block."
     )
 
 

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -500,6 +500,52 @@ def test_F6_bulk_delete_dry_run_rejects_non_member(db_session):
     assert "resources_to_delete" in r2.json()
 
 
+def test_bulk_move_dry_run_requires_source_org_membership(db_session):
+    """
+    Regression guard for the asymmetry that the F6 fix surfaced: bulk_move's
+    dry-run used to permit "member of destination org but not source org",
+    leaking the source org's per-resource counts and name conflicts. The
+    parallel of F6 must apply: source-org membership is always required
+    for dry-run, regardless of whether destination_organization_id is set.
+    """
+    h_admin_src = _h("orgadmin-bm-src", scope="personal")
+    h_admin_dest = _h("orgadmin-bm-dest", scope="personal")
+    client = _client()
+
+    r_src = client.post(
+        "/organizations/",
+        json={"name": "Src Org", "slug": f"src-{uuid.uuid4().hex[:8]}"},
+        headers=h_admin_src,
+    )
+    assert r_src.status_code == 201, r_src.text
+    src_org_id = r_src.json()["id"]
+
+    r_dest = client.post(
+        "/organizations/",
+        json={"name": "Dest Org", "slug": f"dest-{uuid.uuid4().hex[:8]}"},
+        headers=h_admin_dest,
+    )
+    assert r_dest.status_code == 201, r_dest.text
+    dest_org_id = r_dest.json()["id"]
+
+    # admin_dest is in dest_org but NOT src_org; previously this was sufficient
+    # to dry-run a move out of src_org and learn its per-resource counts.
+    r = client.post(
+        f"/bulk-operations/organizations/{src_org_id}/bulk-move",
+        json={
+            "destination_organization_id": dest_org_id,
+            "resource_types": ["agents", "memory_blocks", "keywords"],
+            "dry_run": True,
+        },
+        headers=h_admin_dest,
+    )
+    assert r.status_code == 403, (
+        f"REGRESSION (B asymmetry): dest-only member was permitted to "
+        f"dry-run a bulk-move from a source org they don't belong to. "
+        f"Status={r.status_code}: {r.text}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # D — /user-info host-spoof local-dev fallback. Default ALLOW_LOCAL_DEV_AUTH=true.
 # ---------------------------------------------------------------------------

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -1,0 +1,496 @@
+"""
+End-to-end verification of the data-leak audit findings.
+
+Each test asserts the *current* (vulnerable) behavior — i.e. it PASSES today
+and would FAIL after the corresponding finding is fixed. This makes the suite
+a regression harness for the eventual patches.
+
+Findings under test (see RFC at /tmp/hindsight-security-audit/RFC-data-leak-audit.md):
+
+  F2  email-only identity
+  F1  _basic_search_fallback bypasses scope filter when current_user is None
+      and agent_id is supplied
+  A   apply_consolidation mints new block under original_memory_ids[0].owner
+  B   bulk_move accepts arbitrary destination_owner_user_id
+  F6  bulk_delete dry-run leaks resource counts to non-members
+  D   /user-info local-dev fallback fires on Host: localhost*
+
+Runs against a real Postgres testcontainer (pgvector/pgvector:pg16) configured
+in tests/conftest.py with full Alembic migrations. Per-test transactional
+rollback handles teardown.
+"""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.api.main import app as main_app
+from core.db import models
+
+
+pytestmark = pytest.mark.e2e
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _h(user: str, *, scope: str = "personal") -> dict:
+    """Header set for an oauth2-proxy authenticated user."""
+    return {
+        "x-auth-request-user": user,
+        "x-auth-request-email": f"{user}@example.com",
+        "x-active-scope": scope,
+    }
+
+
+def _client(extra_headers: dict | None = None) -> TestClient:
+    headers = {"x-active-scope": "personal"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return TestClient(main_app, headers=headers)
+
+
+def _guest_client() -> TestClient:
+    """A TestClient that sends no auth headers and no default scope header."""
+    return TestClient(main_app)
+
+
+def _create_personal_memory(client: TestClient, headers: dict, content: str, agent_name: str | None = None) -> dict:
+    agent_name = agent_name or f"agent-{uuid.uuid4().hex[:8]}"
+    r = client.post(
+        "/agents/",
+        json={"agent_name": agent_name, "visibility_scope": "personal"},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    agent_id = r.json()["agent_id"]
+
+    r = client.post(
+        "/memory-blocks/",
+        json={
+            "agent_id": agent_id,
+            "conversation_id": str(uuid.uuid4()),
+            "content": content,
+            "visibility_scope": "personal",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    mb = r.json()
+    mb["_agent_id"] = agent_id
+    return mb
+
+
+# ---------------------------------------------------------------------------
+# F2 — Email-only identity: the same email used by two different "people"
+#       resolves to the same User row, so the second person inherits all data
+#       owned by the first.
+# ---------------------------------------------------------------------------
+
+
+def test_F2_email_collision_grants_account_takeover(db_session):
+    """
+    Two sign-ins with the same email but different display names ("Alice First"
+    vs "Alice Second") MUST resolve to one User row today, since the auth path
+    only filters on `User.email`. The second person's `/user-info` reflects
+    the same user_id and the same personal memory blocks.
+
+    This reproduces the user's reported symptom of "legit data appears in my
+    account" via legitimate (non-malicious) email reassignment.
+    """
+    email = "alice-recycled@example.com"
+
+    # First human signs up as "Alice First", creates a personal memory block.
+    h_first = {
+        "x-auth-request-user": "Alice First",
+        "x-auth-request-email": email,
+        "x-active-scope": "personal",
+    }
+    client_first = _client()
+    secret_content = f"ALICE_FIRST_SECRET_{uuid.uuid4().hex}"
+    mb_first = _create_personal_memory(client_first, h_first, secret_content)
+
+    r_info_first = client_first.get("/user-info", headers=h_first)
+    assert r_info_first.status_code == 200, r_info_first.text
+    user_id_first = r_info_first.json()["user_id"]
+
+    # Second human is given the same email later (e.g. corporate alias reuse)
+    # and signs in with a different display name.
+    h_second = {
+        "x-auth-request-user": "Alice Second",
+        "x-auth-request-email": email,
+        "x-active-scope": "personal",
+    }
+    client_second = _client()
+    r_info_second = client_second.get("/user-info", headers=h_second)
+    assert r_info_second.status_code == 200, r_info_second.text
+    user_id_second = r_info_second.json()["user_id"]
+
+    # BUG: same email -> same user_id -> account takeover.
+    assert user_id_second == user_id_first, (
+        "Email-only identity bug: a second sign-in with the same email got a different "
+        "user_id, which would mean the bug is fixed."
+    )
+
+    # The second human's personal memory listing now contains the first person's secret.
+    r_list = client_second.get("/memory-blocks/", headers=h_second)
+    assert r_list.status_code == 200, r_list.text
+    items = r_list.json()["items"]
+    contents = [it["content"] for it in items]
+    assert secret_content in contents, (
+        "Expected the first user's personal memory block to leak into the second user's listing."
+    )
+
+    # Confirm at the DB layer that exactly one User row exists for this email.
+    rows = db_session.query(models.User).filter(models.User.email == email).all()
+    assert len(rows) == 1, f"Expected 1 User row for {email}, found {len(rows)}"
+
+
+# ---------------------------------------------------------------------------
+# F1 — _basic_search_fallback exposes personal data to guests when agent_id
+#       is supplied.
+# ---------------------------------------------------------------------------
+
+
+def test_F1_guest_basic_search_with_agent_id_returns_personal_data(db_session):
+    """
+    Per `core/services/search_service.py:1133-1141`, when current_user is None
+    AND agent_id (or conversation_id) is supplied, no visibility filter is
+    applied. A guest hitting /memory-blocks/search/?search_type=basic with a
+    known agent_id therefore receives personal memory blocks.
+    """
+    secret_content = f"PERSONAL_LEAK_TARGET_{uuid.uuid4().hex}"
+    h_alice = _h("alice-leak-target")
+    client_authed = _client()
+    mb = _create_personal_memory(client_authed, h_alice, secret_content)
+    agent_id = mb["_agent_id"]
+
+    # Guest: no Authorization, no X-API-Key, no X-Auth-Request-* headers.
+    guest = _guest_client()
+    r = guest.get(
+        "/memory-blocks/search/",
+        params={
+            "keywords": "PERSONAL_LEAK_TARGET",
+            "agent_id": agent_id,
+            "search_type": "basic",
+            "limit": 50,
+        },
+    )
+    assert r.status_code == 200, r.text
+    contents = [item["content"] for item in r.json()]
+    assert secret_content in contents, (
+        "BUG NOT REPRODUCED: guest with agent_id should have received the personal "
+        "memory block, but did not. Either the carve-out at search_service.py:1133-1141 "
+        "is gone or the call path no longer reaches it."
+    )
+
+    # Sanity: same call WITHOUT agent_id should fall back to the public-only
+    # branch and return nothing for this personal block.
+    r2 = guest.get(
+        "/memory-blocks/search/",
+        params={
+            "keywords": "PERSONAL_LEAK_TARGET",
+            "search_type": "basic",
+            "limit": 50,
+        },
+    )
+    assert r2.status_code == 200, r2.text
+    contents2 = [item["content"] for item in r2.json()]
+    assert secret_content not in contents2, (
+        "Sanity check failed: the no-agent_id guest branch should be public-only."
+    )
+
+
+# ---------------------------------------------------------------------------
+# A — Consolidation validate mis-attributes ownership and archives without
+#       checking write permission on every original.
+# ---------------------------------------------------------------------------
+
+
+def test_A_consolidation_validate_minted_under_first_id_owner(db_session):
+    """
+    Build a consolidation suggestion whose original_memory_ids = [bob_mb, alice_mb].
+    Have alice (NOT bob) validate. The new merged block is created with
+    owner_user_id = bob.id (from original_memory_ids[0]) and bob's personal
+    memory is archived without bob's consent or write check.
+
+    The user's reported symptom: bob sees a new "personal" memory in his list
+    that contains content (the LLM-merged suggested_content) he never wrote.
+    """
+    h_alice = _h("alice-consol")
+    h_bob = _h("bob-consol")
+    client_alice = _client()
+    client_bob = _client()
+
+    alice_secret = f"ALICE_PIECE_{uuid.uuid4().hex}"
+    bob_secret = f"BOB_PIECE_{uuid.uuid4().hex}"
+    mb_alice = _create_personal_memory(client_alice, h_alice, alice_secret)
+    mb_bob = _create_personal_memory(client_bob, h_bob, bob_secret)
+
+    # Resolve user ids from /user-info
+    alice_id = client_alice.get("/user-info", headers=h_alice).json()["user_id"]
+    bob_id = client_bob.get("/user-info", headers=h_bob).json()["user_id"]
+
+    merged_content = f"MERGED_FROM_BOTH_{uuid.uuid4().hex}"
+
+    # Insert a consolidation_suggestion row directly (the worker normally does
+    # this; we shortcut the LLM step). original_memory_ids[0] is bob's id, so
+    # the new block will be minted under bob.
+    suggestion = models.ConsolidationSuggestion(
+        group_id=uuid.uuid4(),
+        suggested_content=merged_content,
+        suggested_lessons_learned="MERGED_LESSONS",
+        suggested_keywords=["alpha", "beta"],
+        original_memory_ids=[mb_bob["id"], mb_alice["id"]],
+        status="pending",
+    )
+    db_session.add(suggestion)
+    db_session.commit()
+    suggestion_id = str(suggestion.suggestion_id)
+
+    # Alice validates the suggestion (she can read at least one original — her own).
+    r = client_alice.post(
+        f"/consolidation-suggestions/{suggestion_id}/validate/",
+        headers=h_alice,
+    )
+    assert r.status_code == 200, r.text
+
+    # Refresh from DB and assert the new memory block landed under BOB.
+    db_session.expire_all()
+    new_blocks = (
+        db_session.query(models.MemoryBlock)
+        .filter(models.MemoryBlock.content == merged_content)
+        .all()
+    )
+    assert len(new_blocks) == 1, (
+        f"Expected exactly 1 new merged block, got {len(new_blocks)}"
+    )
+    new_mb = new_blocks[0]
+    assert str(new_mb.owner_user_id) == str(bob_id), (
+        f"BUG NOT REPRODUCED: merged block owner is {new_mb.owner_user_id}, "
+        f"expected bob ({bob_id})."
+    )
+    assert new_mb.visibility_scope == "personal"
+    assert new_mb.archived is False
+
+    # Bob (the unwitting "owner") now sees the merged content in his personal listing.
+    r_list_bob = client_bob.get("/memory-blocks/", headers=h_bob)
+    assert r_list_bob.status_code == 200
+    contents = [it["content"] for it in r_list_bob.json()["items"]]
+    assert merged_content in contents, (
+        "Bob's personal listing should include the merged block he never created."
+    )
+
+    # Both originals are archived (note: alice's was archived by alice's own action,
+    # bob's was archived by alice WITHOUT a write check on bob's row).
+    db_session.expire_all()
+    bob_orig = db_session.query(models.MemoryBlock).filter(models.MemoryBlock.id == uuid.UUID(mb_bob["id"])).first()
+    alice_orig = db_session.query(models.MemoryBlock).filter(models.MemoryBlock.id == uuid.UUID(mb_alice["id"])).first()
+    assert bob_orig.archived is True, "Bob's original should have been archived (without his consent)."
+    assert alice_orig.archived is True
+
+
+# ---------------------------------------------------------------------------
+# B — bulk_move executor honors arbitrary destination_owner_user_id with no
+#       check on the recipient. Tested at the executor layer (the API endpoint
+#       wraps the executor in asyncio.create_task which is fire-and-forget
+#       under TestClient).
+# ---------------------------------------------------------------------------
+
+
+def test_B_bulk_move_executor_does_not_update_visibility_scope(db_session):
+    """
+    `core/async_bulk_operations.py:_move_memory_blocks` (lines 207-227) sets
+    `organization_id = dest_org_id` and `owner_user_id = dest_owner_id` but
+    *does not* update `visibility_scope`. For org→personal moves this produces
+    a row with `visibility_scope='organization'` AND `organization_id=NULL`,
+    which violates the `ck_memory_blocks_org_has_org` check constraint.
+
+    The DB constraint is therefore the *only* thing preventing this code path
+    from silently dropping organization data into a non-member's personal scope.
+    If the constraint is ever relaxed or the executor is patched without also
+    fixing the dest_owner validation, the leak becomes real.
+
+    To avoid SQLAlchemy session-state issues with the conftest's transactional
+    rollback, we exercise the executor's two write statements via a fresh
+    short-lived session. This isolates the IntegrityError to its own session
+    while the suite's outer rollback still cleans up.
+    """
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.orm import sessionmaker
+
+    h_admin = _h("orgadmin-b", scope="personal")
+    h_carol = _h("carol-b", scope="personal")
+    client = _client()
+    carol_info = client.get("/user-info", headers=h_carol).json()
+    carol_id = uuid.UUID(carol_info["user_id"])
+
+    r_org = client.post(
+        "/organizations/",
+        json={"name": "Org B", "slug": f"org-b-{uuid.uuid4().hex[:8]}"},
+        headers=h_admin,
+    )
+    assert r_org.status_code == 201, r_org.text
+    org_id = uuid.UUID(r_org.json()["id"])
+
+    h_admin_org = {**h_admin, "x-active-scope": "organization", "x-organization-id": str(org_id)}
+    r_agent = client.post(
+        "/agents/",
+        json={"agent_name": f"OrgAgent-{uuid.uuid4().hex[:8]}", "visibility_scope": "organization", "organization_id": str(org_id)},
+        headers=h_admin_org,
+    )
+    agent_id = r_agent.json()["agent_id"]
+
+    r_mb = client.post(
+        "/memory-blocks/",
+        json={
+            "agent_id": agent_id,
+            "conversation_id": str(uuid.uuid4()),
+            "content": f"ORG_DATA_LEAK_{uuid.uuid4().hex}",
+            "visibility_scope": "organization",
+            "organization_id": str(org_id),
+        },
+        headers=h_admin_org,
+    )
+    assert r_mb.status_code == 201, r_mb.text
+    mb_id = uuid.UUID(r_mb.json()["id"])
+
+    # Reproduce the executor's exact write logic in a fresh session to avoid
+    # poisoning the conftest session.
+    bind = db_session.get_bind()
+    LocalSession = sessionmaker(bind=bind, autoflush=False, autocommit=False)
+    s2 = LocalSession()
+    try:
+        mb = s2.query(models.MemoryBlock).filter(models.MemoryBlock.id == mb_id).first()
+        assert mb is not None, "Memory block should be visible from the fresh session."
+        # NOTE: the executor does NOT touch visibility_scope. Mirror that.
+        mb.organization_id = None
+        mb.owner_user_id = carol_id
+        leaked_silently = False
+        try:
+            s2.commit()
+            leaked_silently = True
+        except IntegrityError as e:
+            s2.rollback()
+            assert "ck_memory_blocks_org_has_org" in str(e), (
+                f"Expected the org-has-org check constraint to fire; got: {e}"
+            )
+        assert not leaked_silently, (
+            "REGRESSION: the executor's UPDATE was accepted by the DB. The "
+            "ck_memory_blocks_org_has_org constraint that currently saves us "
+            "has been weakened/removed, and `_move_memory_blocks` is missing "
+            "both (a) destination_owner_user_id validation and (b) a "
+            "visibility_scope update. This is now an exploitable silent leak."
+        )
+    finally:
+        s2.close()
+
+
+def test_B_bulk_move_api_accepts_arbitrary_destination_owner_dry_run(db_session):
+    """
+    Independent reproduction at the API layer: the bulk-move dry-run path runs
+    synchronously and is allowed even when destination_owner_user_id is a
+    user the actor has no relationship with. This proves the *authorisation*
+    half of the bug — the recipient's identity is never validated.
+    """
+    h_admin = _h("orgadmin-b2", scope="personal")
+    h_carol = _h("carol-b2", scope="personal")
+    client = _client()
+    carol_info = client.get("/user-info", headers=h_carol).json()
+    carol_id = carol_info["user_id"]
+
+    r_org = client.post(
+        "/organizations/",
+        json={"name": "Org B2", "slug": f"org-b2-{uuid.uuid4().hex[:8]}"},
+        headers=h_admin,
+    )
+    assert r_org.status_code == 201, r_org.text
+    org_id = r_org.json()["id"]
+
+    # Dry-run accepts arbitrary recipient with no relationship to actor or org.
+    r = client.post(
+        f"/bulk-operations/organizations/{org_id}/bulk-move",
+        json={
+            "destination_owner_user_id": carol_id,
+            "resource_types": ["memory_blocks"],
+            "dry_run": True,
+        },
+        headers=h_admin,
+    )
+    assert r.status_code == 200, (
+        f"BUG NOT REPRODUCED: bulk-move dry-run with arbitrary destination_owner_user_id "
+        f"was rejected (status={r.status_code}): {r.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F6 — bulk_delete dry-run leaks resource counts to non-members.
+# ---------------------------------------------------------------------------
+
+
+def test_F6_bulk_delete_dry_run_leaks_counts_to_non_member(db_session):
+    """
+    `bulk_operations.py:262-298` lets any authenticated user submit a delete
+    plan against any organization and learn agent_count / memory_block_count /
+    keyword_count. A small information disclosure, included for completeness.
+    """
+    h_admin = _h("orgadmin-f6", scope="personal")
+    h_outsider = _h("outsider-f6", scope="personal")
+    client = _client()
+
+    r_org = client.post(
+        "/organizations/",
+        json={"name": "Org F6", "slug": f"org-f6-{uuid.uuid4().hex[:8]}"},
+        headers=h_admin,
+    )
+    assert r_org.status_code == 201, r_org.text
+    org_id = r_org.json()["id"]
+
+    # Outsider (not a member) requests dry-run delete plan and gets a 200 with counts.
+    r = client.post(
+        f"/bulk-operations/organizations/{org_id}/bulk-delete",
+        json={"dry_run": True, "resource_types": ["memory_blocks", "agents", "keywords"]},
+        headers=h_outsider,
+    )
+    assert r.status_code == 200, (
+        f"BUG NOT REPRODUCED: outsider was rejected by bulk-delete dry-run "
+        f"(status={r.status_code}): {r.text}"
+    )
+    body = r.json()
+    assert "resources_to_delete" in body
+    assert "memory_blocks" in body["resources_to_delete"]
+    assert "agents" in body["resources_to_delete"]
+    assert "keywords" in body["resources_to_delete"]
+
+
+# ---------------------------------------------------------------------------
+# D — /user-info host-spoof local-dev fallback. Default ALLOW_LOCAL_DEV_AUTH=true.
+# ---------------------------------------------------------------------------
+
+
+def test_D_user_info_localhost_host_fallback_returns_dev_user(db_session, monkeypatch):
+    """
+    `core/api/main.py:361-387`: when no auth headers and no PAT are present,
+    if Host starts with 'localhost' OR client_ip is in (127.0.0.1, ::1, None),
+    `/user-info` returns the dev user `dev@localhost` with full memberships.
+
+    TestClient sets `host = testserver` by default, so we override it.
+    """
+    monkeypatch.setenv("ALLOW_LOCAL_DEV_AUTH", "true")
+    # Make sure DEV_MODE itself is OFF so we hit the local-dev fallback branch,
+    # not the dev-mode branch.
+    monkeypatch.delenv("DEV_MODE", raising=False)
+
+    client = _guest_client()
+    r = client.get("/user-info", headers={"host": "localhost.evil.example.com"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("authenticated") is True, (
+        f"BUG NOT REPRODUCED: localhost-host fallback did not authenticate the request. "
+        f"Body: {body}"
+    )
+    assert body.get("email") == "dev@localhost"

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -92,15 +92,12 @@ def _create_personal_memory(client: TestClient, headers: dict, content: str, age
 # ---------------------------------------------------------------------------
 
 
-def test_F2_email_collision_grants_account_takeover(db_session):
+def test_F2_email_recycle_attempt_is_rejected(db_session):
     """
-    Two sign-ins with the same email but different display names ("Alice First"
-    vs "Alice Second") MUST resolve to one User row today, since the auth path
-    only filters on `User.email`. The second person's `/user-info` reflects
-    the same user_id and the same personal memory blocks.
-
-    This reproduces the user's reported symptom of "legit data appears in my
-    account" via legitimate (non-malicious) email reassignment.
+    Regression guard for F2: when an existing User row was first registered
+    with one external_subject (X-Auth-Request-User), a later sign-in using
+    the same email but a *different* external_subject MUST be rejected. This
+    blocks the silent account-inheritance path described in the audit RFC.
     """
     email = "alice-recycled@example.com"
 
@@ -112,14 +109,22 @@ def test_F2_email_collision_grants_account_takeover(db_session):
     }
     client_first = _client()
     secret_content = f"ALICE_FIRST_SECRET_{uuid.uuid4().hex}"
-    mb_first = _create_personal_memory(client_first, h_first, secret_content)
+    _create_personal_memory(client_first, h_first, secret_content)
 
     r_info_first = client_first.get("/user-info", headers=h_first)
     assert r_info_first.status_code == 200, r_info_first.text
-    user_id_first = r_info_first.json()["user_id"]
 
-    # Second human is given the same email later (e.g. corporate alias reuse)
-    # and signs in with a different display name.
+    # Confirm the User row was bound to the first subject.
+    db_session.expire_all()
+    user_row = db_session.query(models.User).filter(models.User.email == email).one()
+    assert user_row.external_subject == "Alice First", (
+        f"User row should have external_subject bound to the first sign-in's "
+        f"X-Auth-Request-User, got {user_row.external_subject!r}."
+    )
+
+    # Second human attempts to sign in with the same email but a different
+    # X-Auth-Request-User. /user-info must refuse with 401, NOT mint or
+    # reuse the existing row.
     h_second = {
         "x-auth-request-user": "Alice Second",
         "x-auth-request-email": email,
@@ -127,27 +132,32 @@ def test_F2_email_collision_grants_account_takeover(db_session):
     }
     client_second = _client()
     r_info_second = client_second.get("/user-info", headers=h_second)
-    assert r_info_second.status_code == 200, r_info_second.text
-    user_id_second = r_info_second.json()["user_id"]
-
-    # BUG: same email -> same user_id -> account takeover.
-    assert user_id_second == user_id_first, (
-        "Email-only identity bug: a second sign-in with the same email got a different "
-        "user_id, which would mean the bug is fixed."
+    assert r_info_second.status_code == 401, (
+        f"REGRESSION (F2): second sign-in with mismatched external_subject "
+        f"returned {r_info_second.status_code}. Body: {r_info_second.text}"
     )
 
-    # The second human's personal memory listing now contains the first person's secret.
+    # The unauthenticated second human cannot list /memory-blocks/ either.
+    # (write paths are blocked by the read-only middleware; reads via
+    # /memory-blocks/ require auth too because there's no PAT and no valid
+    # oauth header pair.)
     r_list = client_second.get("/memory-blocks/", headers=h_second)
-    assert r_list.status_code == 200, r_list.text
-    items = r_list.json()["items"]
-    contents = [it["content"] for it in items]
-    assert secret_content in contents, (
-        "Expected the first user's personal memory block to leak into the second user's listing."
-    )
+    if r_list.status_code == 200:
+        # If the endpoint accepts the second client at all, it must NOT have
+        # surfaced the first user's secret. With the F2 guard, reaching the
+        # full memory-blocks listing requires a separate auth path; we only
+        # care that the leak is gone.
+        contents = [it["content"] for it in r_list.json().get("items", [])]
+        assert secret_content not in contents, (
+            "REGRESSION (F2): first user's personal memory block was visible "
+            "to the second sign-in attempt."
+        )
 
-    # Confirm at the DB layer that exactly one User row exists for this email.
+    # Exactly one User row for this email — no second was created.
+    db_session.expire_all()
     rows = db_session.query(models.User).filter(models.User.email == email).all()
     assert len(rows) == 1, f"Expected 1 User row for {email}, found {len(rows)}"
+    assert rows[0].external_subject == "Alice First"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
+++ b/apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py
@@ -223,15 +223,13 @@ def test_F1_guest_basic_search_with_agent_id_does_not_leak_personal_data(db_sess
 # ---------------------------------------------------------------------------
 
 
-def test_A_consolidation_validate_minted_under_first_id_owner(db_session):
+def test_A_consolidation_validate_rejects_cross_owner_suggestion(db_session):
     """
-    Build a consolidation suggestion whose original_memory_ids = [bob_mb, alice_mb].
-    Have alice (NOT bob) validate. The new merged block is created with
-    owner_user_id = bob.id (from original_memory_ids[0]) and bob's personal
-    memory is archived without bob's consent or write check.
-
-    The user's reported symptom: bob sees a new "personal" memory in his list
-    that contains content (the LLM-merged suggested_content) he never wrote.
+    Regression guard for A: validating a consolidation suggestion whose
+    `original_memory_ids` span more than one (scope, owner, org) tuple must
+    be refused. Otherwise the new merged block is minted under
+    `original_memory_ids[0].owner_user_id` and originals are archived
+    without a write-access check on every original.
     """
     h_alice = _h("alice-consol")
     h_bob = _h("bob-consol")
@@ -243,15 +241,7 @@ def test_A_consolidation_validate_minted_under_first_id_owner(db_session):
     mb_alice = _create_personal_memory(client_alice, h_alice, alice_secret)
     mb_bob = _create_personal_memory(client_bob, h_bob, bob_secret)
 
-    # Resolve user ids from /user-info
-    alice_id = client_alice.get("/user-info", headers=h_alice).json()["user_id"]
-    bob_id = client_bob.get("/user-info", headers=h_bob).json()["user_id"]
-
     merged_content = f"MERGED_FROM_BOTH_{uuid.uuid4().hex}"
-
-    # Insert a consolidation_suggestion row directly (the worker normally does
-    # this; we shortcut the LLM step). original_memory_ids[0] is bob's id, so
-    # the new block will be minted under bob.
     suggestion = models.ConsolidationSuggestion(
         group_id=uuid.uuid4(),
         suggested_content=merged_content,
@@ -264,46 +254,52 @@ def test_A_consolidation_validate_minted_under_first_id_owner(db_session):
     db_session.commit()
     suggestion_id = str(suggestion.suggestion_id)
 
-    # Alice validates the suggestion (she can read at least one original — her own).
+    # Alice attempts to validate — she lacks write access on bob's original AND
+    # the originals span owners. Either the 403 (write-on-every-original) or
+    # the 409 (cross-owner) check should reject; the bug previously returned 200.
     r = client_alice.post(
         f"/consolidation-suggestions/{suggestion_id}/validate/",
         headers=h_alice,
     )
-    assert r.status_code == 200, r.text
+    assert r.status_code in (403, 409), (
+        f"REGRESSION (A): cross-owner validation returned {r.status_code}. "
+        f"Body: {r.text}"
+    )
 
-    # Refresh from DB and assert the new memory block landed under BOB.
+    # No merged block was created and no original was archived.
     db_session.expire_all()
     new_blocks = (
         db_session.query(models.MemoryBlock)
         .filter(models.MemoryBlock.content == merged_content)
         .all()
     )
-    assert len(new_blocks) == 1, (
-        f"Expected exactly 1 new merged block, got {len(new_blocks)}"
+    assert new_blocks == [], (
+        f"REGRESSION (A): a merged block was created despite rejection. Found: {new_blocks}"
     )
-    new_mb = new_blocks[0]
-    assert str(new_mb.owner_user_id) == str(bob_id), (
-        f"BUG NOT REPRODUCED: merged block owner is {new_mb.owner_user_id}, "
-        f"expected bob ({bob_id})."
-    )
-    assert new_mb.visibility_scope == "personal"
-    assert new_mb.archived is False
-
-    # Bob (the unwitting "owner") now sees the merged content in his personal listing.
-    r_list_bob = client_bob.get("/memory-blocks/", headers=h_bob)
-    assert r_list_bob.status_code == 200
-    contents = [it["content"] for it in r_list_bob.json()["items"]]
-    assert merged_content in contents, (
-        "Bob's personal listing should include the merged block he never created."
-    )
-
-    # Both originals are archived (note: alice's was archived by alice's own action,
-    # bob's was archived by alice WITHOUT a write check on bob's row).
-    db_session.expire_all()
     bob_orig = db_session.query(models.MemoryBlock).filter(models.MemoryBlock.id == uuid.UUID(mb_bob["id"])).first()
     alice_orig = db_session.query(models.MemoryBlock).filter(models.MemoryBlock.id == uuid.UUID(mb_alice["id"])).first()
-    assert bob_orig.archived is True, "Bob's original should have been archived (without his consent)."
-    assert alice_orig.archived is True
+    assert bob_orig.archived is False, "Bob's memory must not have been archived by alice's failed attempt."
+    assert alice_orig.archived is False, "Alice's memory must not have been archived by her failed attempt."
+
+    # Positive case: a same-owner suggestion (alice over alice's own blocks) still works.
+    alice_secret2 = f"ALICE_PIECE2_{uuid.uuid4().hex}"
+    mb_alice2 = _create_personal_memory(client_alice, h_alice, alice_secret2)
+    same_owner_suggestion = models.ConsolidationSuggestion(
+        group_id=uuid.uuid4(),
+        suggested_content=f"ALICE_MERGED_{uuid.uuid4().hex}",
+        suggested_lessons_learned="MERGED_LESSONS",
+        suggested_keywords=["alpha"],
+        original_memory_ids=[mb_alice["id"], mb_alice2["id"]],
+        status="pending",
+    )
+    db_session.add(same_owner_suggestion)
+    db_session.commit()
+    sid = str(same_owner_suggestion.suggestion_id)
+    r2 = client_alice.post(
+        f"/consolidation-suggestions/{sid}/validate/",
+        headers=h_alice,
+    )
+    assert r2.status_code == 200, r2.text
 
 
 # ---------------------------------------------------------------------------

--- a/apps/hindsight-service/tests/integration/keywords/test_keywords_api.py
+++ b/apps/hindsight-service/tests/integration/keywords/test_keywords_api.py
@@ -6,10 +6,14 @@ client = TestClient(app, headers={"X-Active-Scope": "personal"})
 
 # Helper to build auth headers
 
-def auth(email="user@example.com", name="User"):
+def auth(email="user@example.com", name=None):
+    # Use the email as the X-Auth-Request-User default so different emails
+    # imply different external_subjects. Real OIDC subs are unique per
+    # account; the previous shared-name default was a test-only quirk that
+    # collided with the new partial-unique index on users.external_subject.
     return {
         "x-auth-request-email": email,
-        "x-auth-request-user": name,
+        "x-auth-request-user": name or email,
     }
 
 def test_create_personal_keyword():

--- a/apps/hindsight-service/tests/integration/memory_blocks/test_consolidation_suggestions.py
+++ b/apps/hindsight-service/tests/integration/memory_blocks/test_consolidation_suggestions.py
@@ -3,20 +3,25 @@ from datetime import datetime, timezone
 from core.db import models, crud, schemas
 
 
-def _seed_memory_block(db, content="Base Content"):
-    user = models.User(email=f"cuser_{uuid.uuid4().hex}@ex.com", display_name="CU", is_superadmin=False)
-    db.add(user); db.commit(); db.refresh(user)
-    agent = models.Agent(agent_name=f"CAgent {uuid.uuid4().hex[:5]}", visibility_scope="personal", owner_user_id=user.id)
-    db.add(agent); db.commit(); db.refresh(agent)
-    mb = models.MemoryBlock(agent_id=agent.agent_id, conversation_id=uuid.uuid4(), content=content, lessons_learned="LL", visibility_scope="personal", owner_user_id=user.id)
+def _seed_memory_block(db, content="Base Content", *, owner=None, agent=None):
+    """Create a memory block. If `owner`/`agent` are provided reuse them so the
+    caller can group originals under a single (owner, agent) tuple — required
+    by apply_consolidation's same-owner invariant."""
+    if owner is None:
+        owner = models.User(email=f"cuser_{uuid.uuid4().hex}@ex.com", display_name="CU", is_superadmin=False)
+        db.add(owner); db.commit(); db.refresh(owner)
+    if agent is None:
+        agent = models.Agent(agent_name=f"CAgent {uuid.uuid4().hex[:5]}", visibility_scope="personal", owner_user_id=owner.id)
+        db.add(agent); db.commit(); db.refresh(agent)
+    mb = models.MemoryBlock(agent_id=agent.agent_id, conversation_id=uuid.uuid4(), content=content, lessons_learned="LL", visibility_scope="personal", owner_user_id=owner.id)
     db.add(mb); db.commit(); db.refresh(mb)
-    return mb, agent
+    return mb, agent, owner
 
 
 def test_consolidation_full_flow(db_session):
     db = db_session
-    mb1, agent = _seed_memory_block(db, "First piece")
-    mb2, _ = _seed_memory_block(db, "Second piece")
+    mb1, agent, owner = _seed_memory_block(db, "First piece")
+    mb2, _, _ = _seed_memory_block(db, "Second piece", owner=owner, agent=agent)
 
     group_id = uuid.uuid4()
     create_payload = schemas.ConsolidationSuggestionCreate(

--- a/apps/hindsight-service/tests/integration/memory_blocks/test_memory_blocks_advanced.py
+++ b/apps/hindsight-service/tests/integration/memory_blocks/test_memory_blocks_advanced.py
@@ -56,6 +56,9 @@ def test_memory_block_filters_and_archive(db_session):
     )
     assert kw_blocks
 
-    # Retrieval by keywords simple function
-    retrieved = crud.retrieve_relevant_memories(db, ["alpha"], agent_id=agent_p.agent_id)
+    # Retrieval by keywords simple function — pass current_user so the
+    # search service applies the correct scope filter for the owner.
+    retrieved = crud.retrieve_relevant_memories(
+        db, ["alpha"], agent_id=agent_p.agent_id, current_user=ctx
+    )
     assert any("alpha".lower() in (r.content.lower()) for r in retrieved)

--- a/apps/hindsight-service/tests/integration/organizations/test_organizations_api.py
+++ b/apps/hindsight-service/tests/integration/organizations/test_organizations_api.py
@@ -5,8 +5,11 @@ import uuid
 client = TestClient(app, headers={"X-Active-Scope": "personal"})
 
 
-def auth(email="orguser@example.com", name="OrgUser"):
-    return {"x-auth-request-email": email, "x-auth-request-user": name}
+def auth(email="orguser@example.com", name=None):
+    # Default X-Auth-Request-User to the email so distinct emails imply
+    # distinct external_subjects (matches OIDC sub uniqueness; avoids
+    # collision with the partial-unique index on users.external_subject).
+    return {"x-auth-request-email": email, "x-auth-request-user": name or email}
 
 
 def test_create_org_no_email():

--- a/apps/hindsight-service/tests/unit/test_bulk_ops_api_smoke.py
+++ b/apps/hindsight-service/tests/unit/test_bulk_ops_api_smoke.py
@@ -24,10 +24,13 @@ def test_bulk_ops_inventory_and_dry_runs():
     inv = r_inv.json()
     assert set(inv.keys()) == {"agent_count", "memory_block_count", "keyword_count"}
 
-    # Dry-run bulk move with destination_owner_user_id only (allowed membership path)
+    # Dry-run bulk move with destination_owner_user_id = actor's own id
+    # (the only non-superadmin recipient allowed; see fix B).
+    r_info = client.get("/user-info", headers=_h("owner", owner_email))
+    actor_id = r_info.json()["user_id"]
     payload_move = {
         "dry_run": True,
-        "destination_owner_user_id": str(uuid.uuid4()),
+        "destination_owner_user_id": actor_id,
         "resource_types": ["agents", "memory_blocks", "keywords"],
     }
     r_move = client.post(f"/bulk-operations/organizations/{org_id}/bulk-move", json=payload_move, headers=_h("owner", owner_email))

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -60,6 +60,8 @@ services:
       OAUTH2_PROXY_SET_XAUTHREQUEST: true
       OAUTH2_PROXY_PASS_ACCESS_TOKEN: true
       OAUTH2_PROXY_SET_AUTHORIZATION_HEADER: true
+      # Pin X-Auth-Request-User to the OIDC `sub` claim — see docker-compose.yml.
+      OAUTH2_PROXY_USER_ID_CLAIM: sub
       OAUTH2_PROXY_EMAIL_DOMAINS: ${OAUTH2_PROXY_EMAIL_DOMAINS:-*}
       OAUTH2_PROXY_SKIP_AUTH_ROUTES: /manifest.json$,/favicon.ico$,^/guest-api/.*
       OAUTH2_PROXY_CLIENT_ID: ${OAUTH2_PROXY_CLIENT_ID}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,10 @@ services:
       APP_BASE_URL: ${APP_BASE_URL}
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:${POSTGRES_PORT}/${POSTGRES_DB}
       DEV_MODE: ${DEV_MODE}
+      # Local-dev fallback in /user-info now defaults OFF in production. The dev
+      # stack still wants it on so a fresh `docker-compose -f docker-compose.dev.yml up`
+      # can serve the dashboard without an oauth2-proxy round-trip.
+      ALLOW_LOCAL_DEV_AUTH: ${ALLOW_LOCAL_DEV_AUTH:-true}
       BUILD_SHA: ${BACKEND_BUILD_SHA}
       BUILD_TIMESTAMP: ${BUILD_TIMESTAMP}
       IMAGE_TAG: ${BACKEND_IMAGE_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,12 @@ services:
       OAUTH2_PROXY_SET_XAUTHREQUEST: true
       OAUTH2_PROXY_PASS_ACCESS_TOKEN: true
       OAUTH2_PROXY_SET_AUTHORIZATION_HEADER: true
+      # Pin X-Auth-Request-User to the OIDC `sub` claim. Backend uses this
+      # value as `external_subject` to detect email-reuse / IdP collision
+      # (core.api.auth.get_or_create_user). With the default
+      # `preferred_username`, this header would equal the email for Google
+      # and the binding would silently no-op.
+      OAUTH2_PROXY_USER_ID_CLAIM: sub
       OAUTH2_PROXY_EMAIL_DOMAINS: ${OAUTH2_PROXY_EMAIL_DOMAINS:-*}
       # Allow unauthenticated access to trivial assets to avoid noisy 401s
       OAUTH2_PROXY_SKIP_AUTH_ROUTES: /manifest.json$,/favicon.ico$,^/guest-api/.*

--- a/scripts/security_pre_deploy_checks.sh
+++ b/scripts/security_pre_deploy_checks.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Pre-deploy probes for the data-isolation security fixes.
+#
+# Run this against a production-equivalent database (or a recent backup
+# snapshot) BEFORE deploying the fixes for findings A, F2, F5, and E. Each
+# probe maps to a class of pre-existing data state that the fixes will
+# either reject (and break a workflow) or surface (and trigger a lockout).
+#
+# Required env: DATABASE_URL or PGHOST/PGUSER/PGDATABASE/PGPASSWORD.
+#
+# Usage:
+#   ./scripts/security_pre_deploy_checks.sh
+#
+# Exit code is non-zero if any probe returned rows; that means the
+# operator needs to act before deploying (or accept the listed breakage).
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]] && [[ -z "${PGHOST:-}" ]]; then
+  echo "Set DATABASE_URL or PGHOST/PGUSER/PGDATABASE/PGPASSWORD." >&2
+  exit 2
+fi
+
+PSQL_ARGS=(-X --tuples-only --quiet -v ON_ERROR_STOP=1)
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  PSQL_ARGS+=("$DATABASE_URL")
+fi
+
+run_probe() {
+  local name="$1"
+  local sql="$2"
+  local advisory="$3"
+  local output
+  output=$(psql "${PSQL_ARGS[@]}" -c "$sql" 2>&1 | sed '/^$/d')
+  if [[ -n "$output" ]]; then
+    echo "==[$name]==============================================="
+    echo "$output"
+    echo
+    echo "Advisory: $advisory"
+    echo
+    return 1
+  else
+    echo "[$name] OK (no rows)"
+    return 0
+  fi
+}
+
+failures=0
+
+# A — pending consolidation suggestions whose originals span owners.
+# After A lands these will return 409 forever from /validate/.
+if ! run_probe \
+  "A.cross_owner_pending_suggestions" \
+  "SELECT cs.suggestion_id, cs.status, COUNT(DISTINCT mb.owner_user_id) AS distinct_owners
+   FROM consolidation_suggestions cs,
+        jsonb_array_elements_text(cs.original_memory_ids) AS oid
+   JOIN memory_blocks mb ON mb.id = oid::uuid
+   WHERE cs.status = 'pending'
+   GROUP BY cs.suggestion_id, cs.status
+   HAVING COUNT(DISTINCT mb.owner_user_id) > 1;" \
+  "Each suggestion above will return 409 from /validate/ after the A fix lands. Either DELETE these rows pre-deploy or accept the breakage."; then
+  failures=$((failures + 1))
+fi
+
+# F2 — users with non-NULL external_subject (should be empty pre-deploy).
+# After F2 deploys and users sign in, this column populates via TOFU. If
+# anyone has it set BEFORE deploy, that means the column already has stale
+# values that may not match what the new oauth2-proxy claim mapping emits.
+if ! run_probe \
+  "F2.users_with_pre_existing_external_subject" \
+  "SELECT id, email, external_subject FROM users WHERE external_subject IS NOT NULL;" \
+  "If F2 has been partially deployed before this run, these rows may need their external_subject cleared (use scripts/rebind_user_subject.py) before reconfiguring oauth2-proxy."; then
+  failures=$((failures + 1))
+fi
+
+# F5 — personal-scoped agents whose memory_blocks span multiple owners.
+# Symptom of the migration backfill picking owner non-deterministically.
+if ! run_probe \
+  "F5.cross_owner_personal_agents" \
+  "SELECT agent_id, COUNT(DISTINCT owner_user_id) AS distinct_owners
+   FROM memory_blocks
+   WHERE visibility_scope = 'personal' AND owner_user_id IS NOT NULL
+   GROUP BY agent_id
+   HAVING COUNT(DISTINCT owner_user_id) > 1;" \
+  "Each agent above has memory blocks owned by multiple users — historical mis-attribution from the 2024-09-15 backfill. Quarantine the affected blocks and pick a single owner per agent."; then
+  failures=$((failures + 1))
+fi
+
+# E — personal-scoped memory blocks with NULL owner_user_id. Should be
+# zero (the ck_*_personal_owner constraint forbids it). If non-zero,
+# the constraint is missing or has been bypassed; the E fix is the only
+# remaining defense.
+if ! run_probe \
+  "E.null_owner_personal_memory_blocks" \
+  "SELECT id, agent_id, visibility_scope FROM memory_blocks
+   WHERE visibility_scope = 'personal' AND owner_user_id IS NULL;" \
+  "Personal-scoped blocks with NULL owner. The DB constraint ck_memory_blocks_personal_owner should forbid this — verify the constraint is present."; then
+  failures=$((failures + 1))
+fi
+
+if [[ $failures -gt 0 ]]; then
+  echo
+  echo "$failures probe(s) reported rows. Review above and act before deploying." >&2
+  exit 1
+fi
+
+echo
+echo "All probes clean. Safe to deploy the security-fix branch."


### PR DESCRIPTION
## Summary

Closes a set of data-isolation defects discovered during a security audit triggered by a user report that "another user's data appeared in my personal account, and it looks legit, not an attack." The audit identified 11 issues; this PR fixes the actionable ones (8 findings + a sibling, plus a follow-up review pass that surfaced 4 more).

Each fix has a paired E2E regression test in `apps/hindsight-service/tests/e2e/test_security_audit_data_leak.py` that asserts the secure behavior.

### Findings addressed

| # | Severity | What | Where |
|---|---|---|---|
| F1 | High | `_basic_search_fallback` skipped scope filter when `current_user is None` AND `agent_id` was supplied — guests on `api.hindsight-ai.com` could read personal data | `core/services/search_service.py` |
| F2 | Critical | User identity keyed only on `email`; `auth_provider`/`external_subject` were dead columns. Recycled email silently inherited the prior holder's row, PATs, memberships | `core/api/auth.py`, `core/api/deps.py`, all header-based callers |
| F3 | Medium | `retrieve_relevant_memories` had an unscoped legacy fallback — dead code that one import away from leaking | `core/db/repositories/memory_blocks.py` |
| F6 | Low | `bulk_delete` dry-run leaked per-resource counts to non-members | `core/api/bulk_operations.py` |
| A | High | `apply_consolidation` minted the merged block under `original_memory_ids[0].owner` regardless of validator; only one original needed to be readable; archived all without write check | `core/api/consolidation.py`, `core/db/crud.py` |
| B | High | `bulk_move` accepted any `destination_owner_user_id` with no recipient consent. Executor didn't update `visibility_scope` (DB constraint was the only line of defense) | `core/api/bulk_operations.py`, `core/async_bulk_operations.py` |
| B asymmetry | High | `bulk_move` dry-run permitted dest-only members to learn source-org counts (the F6 fix's parallel) | `core/api/bulk_operations.py` |
| D | Medium | `/user-info` local-dev fallback fired on `Host: localhost*` — spoofable if backend ever reachable without Traefik. `ALLOW_LOCAL_DEV_AUTH` defaulted true | `core/api/main.py` |
| E | High | `apply_scope_filter` and 3 search-service branches emitted `owner_user_id IS NULL` on a malformed user_ctx without `id` — would match every org row | `core/db/scope_utils.py`, `core/services/search_service.py` |
| change-scope | Medium | Single-block sibling of B; already guarded but locked in with a regression test | `core/api/main.py` (test only) |

### Hardening from review

A multi-agent code review (failure-mode-analyst, test-quality-reviewer, boundary-critic, delivery-pragmatist) caught:

- F2 was effectively a no-op under oauth2-proxy default config (`preferred_username` ≈ email for Google). Pinned `OAUTH2_PROXY_USER_ID_CLAIM=sub` in compose; added a startup warning if the backend ever sees `external_subject == email`.
- `IdentityMismatchError` was leaking as 500-with-stack-trace through 5 call sites; replaced per-callsite translation with a single FastAPI exception handler and routed every header-based caller through one helper (`get_or_create_user_for_request`).
- F2 race: two concurrent first-time logins could race the TOFU bind. Added a partial unique index on `users.external_subject` + `SELECT ... FOR UPDATE` around the bind.
- test_D used `TestClient` whose `client.host` is `'testclient'` — never satisfied the loopback check, so the test passed for the wrong reason. Replaced with httpx + `ASGITransport(client=("127.0.0.1", ...))` so the loopback path is actually exercised, plus a positive case for legitimate local-dev.
- test_A pinned to 403 + new superadmin 409 case so both layers of the A fix are covered.
- `docker-compose.dev.yml` had no explicit `ALLOW_LOCAL_DEV_AUTH` — would have silently broken the dev stack when the default flipped.

### Pre-deploy & operator tooling

- `scripts/security_pre_deploy_checks.sh` — 4 SQL probes the operator should run before deploy (cross-owner pending consolidations, pre-existing `external_subject` rows, F5 multi-owner agents, NULL-owner personal blocks).
- `apps/hindsight-service/scripts/rebind_user_subject.py` — operator recovery if oauth2-proxy claim mapping changes after users are TOFU-bound.

### Migrations

- `2026042900_users_external_subject_unique.py` — partial unique index on `users.external_subject WHERE external_subject IS NOT NULL`.

## Test plan

- [x] `pytest tests/e2e/test_security_audit_data_leak.py` — 13/13 passing
- [x] Full `pytest -m "not e2e"` — 741 passing (excluding `tests/unit/test_beta_access.py` and `tests/unit/test_organization_access_control.py` which have pre-existing fixture issues against `origin/staging` and are not regressed by this branch)
- [ ] Run `./scripts/security_pre_deploy_checks.sh` against staging DB before merging to staging-deploy environment
- [ ] After merge, watch `auth_subject_is_email` warnings in backend logs to confirm `OAUTH2_PROXY_USER_ID_CLAIM=sub` is correctly applied
- [ ] If any user reports a 401 lockout after the claim mapping change, recover with `python -m scripts.rebind_user_subject --email X --clear`

## Out of scope (deferred)

- F4 Traefik default-router routing for `api.hindsight-ai.com` — infra decision.
- F5 historical migration mis-attribution — needs operator action; surfaced by the new pre-deploy probe.
- JWKS-verified ID-token decode — superseded by `OAUTH2_PROXY_USER_ID_CLAIM=sub` for now; can revisit in a follow-up RFC.
- Pre-existing failures in `test_beta_access.py` and `test_organization_access_control.py` — should be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)