### PR TITLE
fix(test-conftest): SAVEPOINT join mode (unblocks PR #48 deploy)

### DIFF
--- a/apps/hindsight-service/tests/conftest.py
+++ b/apps/hindsight-service/tests/conftest.py
@@ -120,12 +120,25 @@ _current_session: ContextVar[object] = ContextVar("_current_session", default=No
 # Fallback for threadpool contexts where ContextVar may not propagate
 _GLOBAL_SESSION = None
 
-# Per-test transactional session (fast cleanup without truncation)
+# Per-test transactional session (fast cleanup without truncation).
+#
+# `join_transaction_mode="create_savepoint"` is the SQLAlchemy 2.x idiom that
+# turns every `session.commit()` into a SAVEPOINT release inside the outer
+# `connection.begin()` transaction (instead of committing the outer tx).
+# Without it, any production code path that calls `db.commit()` while a
+# request is in flight (e.g. the F2 TOFU bind in core.api.auth, or the
+# pre-existing admin/beta-status updates) silently commits the outer tx and
+# leaks state across tests. With it, the outer trans.rollback() at teardown
+# still wipes everything, so each test starts clean even when the handler
+# under test commits multiple times.
+#
+# Reference: https://docs.sqlalchemy.org/en/20/orm/session_transaction.html
+#            #joining-a-session-into-an-external-transaction-such-as-for-test-suites
 @pytest.fixture(autouse=True)
 def db_session(_engine, _SessionLocal):
     connection = _engine.connect()
     trans = connection.begin()
-    session = _SessionLocal(bind=connection)
+    session = _SessionLocal(bind=connection, join_transaction_mode="create_savepoint")
     token = _current_session.set(session)
     global _GLOBAL_SESSION
     _GLOBAL_SESSION = session


### PR DESCRIPTION
## Summary

Follow-up to PR #48. Staging deploy after merging #48 failed at the pytest gate with one test (`tests/unit/test_beta_access.py::TestBetaAccessAPI::test_review_beta_access_endpoint_invalid_decision`) raising `ObjectDeletedError`. Locally I reproduced four failing tests in the same file, all order-dependent.

### Root cause

The conftest pattern at `tests/conftest.py` shares one SQLAlchemy session across the test fixture and the FastAPI request handler (via dependency override) and relies on a single outer `connection.begin()` transaction that gets rolled back at teardown. The pattern silently breaks the moment any production code path calls `session.commit()` mid-request, because that commit propagates to the outer transaction and makes the rows persist across tests.

The pre-F2 codebase already had commit sites in `core.api.auth.get_or_create_user` (admin-promotion at line ~161, beta-status fixup at line ~174). They happened never to fire for the affected tests, so the latent bug was invisible.

PR #48's F2 TOFU bind added a *third* commit site that DOES fire on tests creating raw User rows without an `external_subject`. Once it commits, subsequent tests recreate rows that already leaked, and SQLAlchemy's `expire_on_commit` invalidation surfaces the inconsistency on the very next attribute access — hence `ObjectDeletedError`.

### Fix

Switch the conftest's session creation to the SQLAlchemy 2.x "session joins external transaction" idiom:

```python
session = _SessionLocal(
    bind=connection,
    join_transaction_mode="create_savepoint",
)
```

With `join_transaction_mode="create_savepoint"`, every `session.commit()` is reinterpreted as a SAVEPOINT release inside the outer `connection.begin()` transaction. The outer `trans.rollback()` at teardown still wipes everything, so each test starts clean — even when the handler under test commits multiple times.

This is the canonical SQLAlchemy idiom for shared-session test fixtures: [docs](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites). It hardens the conftest against the existing commits AND any future ones — no production code is changed.

## Verification

- `pytest -m "not e2e" --ignore=tests/unit/test_organization_access_control.py`: **817 passed** (was 813 passed / 4 failed pre-fix on this branch's parent commit).
- `pytest tests/e2e/test_security_audit_data_leak.py`: **13 / 13** (security regression suite from PR #48 still green).
- `tests/unit/test_organization_access_control.py` and the rest of `tests/unit/test_beta_access.py` retain their pre-existing failure pattern (DB-not-migrated for the `tests/unit/` conftest override) — unrelated to this fix.

## Test plan

- [x] Targeted run of the 4 previously failing beta-access tests, plus the rest of `test_beta_access.py` and `test_main_endpoints.py`.
- [x] Full unit+integration suite locally.
- [x] Security regression suite locally.
- [ ] Confirm CI passes on this branch and `staging` deploys cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)