### PR TITLE
fix(test-auth-deps): wire local FastAPI apps to test session (unblocks staging)

### DIFF
--- a/apps/hindsight-service/tests/unit/test_auth_deps.py
+++ b/apps/hindsight-service/tests/unit/test_auth_deps.py
@@ -3,6 +3,22 @@ from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from core.api.deps import get_current_user_context
+from core.db.database import get_db
+
+
+def _wire_local_app_to_test_session(app: FastAPI) -> None:
+    """Make a test-only FastAPI app share the conftest's transactional session.
+
+    Without this, `get_db` falls back to its production implementation, which
+    opens fresh sessions on the engine pool. Those sessions commit straight
+    through to the testcontainer Postgres and the writes persist across tests
+    — which leaks state and (post-F2) causes IdentityMismatchError 401s in
+    later tests that send a different X-Auth-Request-User for the same email.
+    """
+    # Imported lazily so this module can be imported even outside pytest.
+    from tests.conftest import _override_get_db  # type: ignore
+
+    app.dependency_overrides[get_db] = _override_get_db
 
 
 def test_get_current_user_context_unauthorized(monkeypatch):
@@ -11,6 +27,7 @@ def test_get_current_user_context_unauthorized(monkeypatch):
     monkeypatch.setenv("APP_BASE_URL", "http://localhost:3000")
 
     app = FastAPI()
+    _wire_local_app_to_test_session(app)
 
     @app.get("/me")
     def me(user_ctx = Depends(get_current_user_context)):
@@ -26,6 +43,7 @@ def test_get_current_user_context_dev_mode(monkeypatch):
     monkeypatch.setenv("APP_BASE_URL", "http://localhost:3000")
 
     app = FastAPI()
+    _wire_local_app_to_test_session(app)
 
     @app.get("/me")
     def me(user_ctx = Depends(get_current_user_context)):
@@ -47,6 +65,7 @@ def test_admin_emails_elevation(monkeypatch):
     monkeypatch.setenv("ADMIN_EMAILS", admin_email)
 
     app = FastAPI()
+    _wire_local_app_to_test_session(app)
 
     @app.get("/me")
     def me(user_ctx = Depends(get_current_user_context)):
@@ -68,6 +87,7 @@ def test_admin_emails_do_not_elevate_others(monkeypatch):
     monkeypatch.setenv("ADMIN_EMAILS", "privileged@example.com")
 
     app = FastAPI()
+    _wire_local_app_to_test_session(app)
 
     @app.get("/me")
     def me(user_ctx = Depends(get_current_user_context)):


### PR DESCRIPTION
## Summary

After PR #49's conftest savepoint fix unblocked `test_beta_access`, the staging Deploy run [25073118987](https://github.com/hindsight-ai/hindsight-ai/actions/runs/25073118987) failed at a different test — `tests/unit/test_organization_access_control.py::TestOrganizationEndpoints::test_list_organizations_admin_forbidden_for_regular_user` returned 401 instead of 403.

### Root cause

`tests/unit/test_auth_deps.py` builds *local* FastAPI apps (`app = FastAPI()`) and never applies the conftest's `get_db` dependency override. Its requests therefore use the production `get_db`, which opens fresh sessions on the engine pool. Those sessions commit straight through to the testcontainer Postgres and the writes survive across tests.

Specifically:

1. `test_admin_emails_do_not_elevate_others` posts `regular@example.com` with `X-Auth-Request-User: "Regular"` (capital R). PR #48's F2 TOFU bind permanently writes `external_subject="Regular"` on that row.
2. Later, `test_list_organizations_admin_forbidden_for_regular_user` posts the same email with `"regular"` (lowercase). The F2 mismatch guard correctly raises `IdentityMismatchError` → global handler returns 401 → test fails (it expected 403).

The F2 guard is doing exactly what it should — surfacing two different "humans" claiming the same email. The test fixture is what's wrong: it bypassed the conftest's session isolation.

### Fix

Introduce `_wire_local_app_to_test_session(app)` and apply it to every local app in `test_auth_deps.py`. The helper redirects `get_db` to the conftest's `_override_get_db`, so writes happen inside the per-test SAVEPOINT and are rolled back at fixture teardown.

Test-only change; no production code touched.

## Verification

- `pytest -m "not e2e"`: **828 passed** (was 1 failed at org-admin-forbidden).
- `pytest tests/e2e/test_security_audit_data_leak.py`: **13 / 13** still green.

## Test plan

- [x] Run failing test locally — passes.
- [x] Run full unit+integration suite locally — 828 passing.
- [x] Run security E2E suite locally — 13/13.
- [ ] Confirm CI passes and `staging` deploys cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)