### PR TITLE
fix: map /tokens and /memory-optimization-center page titles (RFC 0002 H3)

### DIFF
--- a/apps/hindsight-dashboard/src/App.tsx
+++ b/apps/hindsight-dashboard/src/App.tsx
@@ -287,6 +287,7 @@ function AppContent() {
     const routeMap: Record<string, string> = {
       '/dashboard': 'Dashboard',
       '/profile': 'Profile',
+      '/tokens': 'Tokens',
       '/memory-blocks': 'Memory Blocks',
       '/keywords': 'Keywords',
       '/agents': 'Agents',
@@ -294,6 +295,7 @@ function AppContent() {
       '/consolidation-suggestions': 'Consolidation',
       '/archived-memory-blocks': 'Archived',
       '/pruning-suggestions': 'Pruning',
+      '/memory-optimization-center': 'AI Optimization',
       '/support': 'Support'
     };
     if (pathname.startsWith('/memory-blocks/')) return 'Memory Block Detail';

--- a/apps/hindsight-dashboard/src/components/MainContent.tsx
+++ b/apps/hindsight-dashboard/src/components/MainContent.tsx
@@ -56,6 +56,7 @@ const MainContent: React.FC<MainContentProps> = ({ children, title, sidebarColla
     Support: 'Find help resources and reach out for assistance with Hindsight AI.',
     Profile: 'Update your personal details and notification preferences.',
     Tokens: 'Create and manage API tokens for integrations and automations.',
+    'AI Optimization': 'Review AI-generated suggestions to compact, merge, or archive memory blocks.',
     'Memory Block Detail': 'Inspect the full contents and metadata for a specific memory block.',
     'Consolidation Detail': 'Inspect a consolidation suggestion in depth before making changes.'
   }), []);


### PR DESCRIPTION
## Summary

Fixes finding **H3** from RFC 0002 (UI/UX audit, see PR #51).

`App.tsx`'s `getPageTitle` had a hardcoded `routeMap` missing entries for
`/tokens` and `/memory-optimization-center`. Both are registered routes
(`App.tsx:317` and `App.tsx:327`), so users navigating to either page hit
the fallback at line 301 and saw **"Dashboard"** as the page title.

Two-line change in `App.tsx` plus a matching description for "AI
Optimization" in `MainContent.tsx`'s `defaultDescriptions` map. Title
text mirrors the sidebar label ("AI Optimization", `Sidebar.tsx:54`) so
users see continuity between nav and header.

## Test plan

- [x] `npm run test -- --runInBand` (dashboard) — 256 / 256 passing.
- [x] Visual: Tokens and AI Optimization pages now show their correct
  page titles instead of "Dashboard". (Reviewer to confirm against the
  next audit run, since RFC 0002's screenshot baseline was captured
  *before* this fix.)
- [x] Audit script (`.claude/skills/ui-ux-audit/`, lands in #51) will
  catch any future re-introduction of this regression because the title
  is rendered as `<h2>` in `MainContent.tsx:105` and visible in every
  route screenshot.

## Notes

- Lint and typecheck baselines on `staging` are pre-existing-broken
  (171 lint errors from missing typescript-eslint parser config; ~206
  typecheck errors). This PR adds zero new lint/typecheck issues. CI
  doesn't gate on either — only Jest runs.
- Why no unit test: `getPageTitle` is a private inner function, and a
  bare entry-presence test would just assert the source matches itself.
  A meaningful regression guard would need AST coupling to `<Routes>`
  (overkill) or render-and-assert with heavy mock plumbing. The audit
  script catches title drift at the page level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)