### PR TITLE
fix: decouple GetStarted seen-flag + add Esc/backdrop (RFC 0002 H4+M5)

### DIFF
--- a/apps/hindsight-dashboard/src/App.tsx
+++ b/apps/hindsight-dashboard/src/App.tsx
@@ -78,6 +78,13 @@ function AppContent() {
   }, []);
 
   const handleCloseGetStarted = useCallback(() => {
+    // Transient close (X button, Escape, backdrop) — do NOT mark seen.
+    // An accidental Esc on first load shouldn't permanently silence the
+    // guide for that user.
+    setShowGetStarted(false);
+  }, []);
+
+  const handleAcknowledgeGetStarted = useCallback(() => {
     markGetStartedSeen();
     setShowGetStarted(false);
   }, [markGetStartedSeen]);
@@ -331,7 +338,11 @@ function AppContent() {
         </Routes>
       </Layout>
       <AboutModal isOpen={showAboutModal} onClose={() => setShowAboutModal(false)} />
-      <GetStartedModal isOpen={showGetStarted} onClose={handleCloseGetStarted} />
+      <GetStartedModal
+        isOpen={showGetStarted}
+        onClose={handleCloseGetStarted}
+        onAcknowledge={handleAcknowledgeGetStarted}
+      />
     </div>
   );
 }

--- a/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
+++ b/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
@@ -3,7 +3,13 @@ import Portal from './Portal';
 
 interface GetStartedModalProps {
   isOpen: boolean;
+  // Transient close: X button, Escape, backdrop click. Does NOT mark
+  // the guide as seen — so an accidental Esc on first load doesn't
+  // permanently silence the modal for that user.
   onClose: () => void;
+  // Acknowledged dismiss: "Got it" button. Caller is expected to mark
+  // the guide as seen so it doesn't auto-open again.
+  onAcknowledge: () => void;
 }
 
 type ClientStatus = 'ready' | 'comingSoon';
@@ -210,7 +216,19 @@ const workflowGroups: WorkflowGroup[] = [
   },
 ];
 
-const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose }) => {
+const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose, onAcknowledge }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
   const clientOptions = useMemo((): ClientInfo[] => {
     const clients: ClientInfo[] = [
       {
@@ -460,12 +478,6 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose }) =>
     }
   };
 
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      onClose();
-    }
-  };
-
   const renderSnippet = (snippet: Snippet) => (
     <div key={snippet.id} className="mt-4">
       <div className="flex items-center justify-between gap-3">
@@ -569,8 +581,12 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose }) =>
 
   return (
     <Portal>
-      <div className="fixed inset-0 z-50 flex items-center justify-center px-4" onClick={handleBackdropClick}>
-        <div className="absolute inset-0 bg-gray-900/70" />
+      <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+        <div
+          className="absolute inset-0 bg-gray-900/70"
+          onClick={onClose}
+          aria-hidden="true"
+        />
         <div className="relative w-full max-w-4xl bg-white rounded-2xl shadow-2xl overflow-hidden">
           <header className="flex items-center justify-between px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-indigo-500/10 to-blue-500/10">
             <div>
@@ -641,7 +657,7 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose }) =>
             <div className="flex items-center gap-3">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={onAcknowledge}
                 className="inline-flex items-center justify-center rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition"
               >
                 Got it

--- a/apps/hindsight-dashboard/src/components/__tests__/GetStartedModal.test.tsx
+++ b/apps/hindsight-dashboard/src/components/__tests__/GetStartedModal.test.tsx
@@ -4,12 +4,14 @@ import GetStartedModal from '../GetStartedModal';
 
 describe('GetStartedModal', () => {
   it('does not render when closed', () => {
-    const { container } = render(<GetStartedModal isOpen={false} onClose={jest.fn()} />);
+    const { container } = render(
+      <GetStartedModal isOpen={false} onClose={jest.fn()} onAcknowledge={jest.fn()} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it('renders Codex CLI instructions by default', () => {
-    render(<GetStartedModal isOpen onClose={jest.fn()} />);
+    render(<GetStartedModal isOpen onClose={jest.fn()} onAcknowledge={jest.fn()} />);
 
     expect(screen.getByText('Get Started with Hindsight AI')).toBeInTheDocument();
     expect(screen.getByText('Prepare your Hindsight workspace')).toBeInTheDocument();
@@ -24,7 +26,7 @@ describe('GetStartedModal', () => {
   });
 
   it('renders Claude Code instructions when selected', () => {
-    render(<GetStartedModal isOpen onClose={jest.fn()} />);
+    render(<GetStartedModal isOpen onClose={jest.fn()} onAcknowledge={jest.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Claude Code/i }));
     expect(screen.getByText('Configure Claude Code')).toBeInTheDocument();
@@ -33,12 +35,65 @@ describe('GetStartedModal', () => {
     expect(screen.queryByText('~/.config/codex.toml')).not.toBeInTheDocument();
   });
 
-  it('calls onClose when the close button is pressed', () => {
-    const handleClose = jest.fn();
-    render(<GetStartedModal isOpen onClose={handleClose} />);
+  // Transient close paths — must NOT mark the guide as seen. App.tsx
+  // wires `onClose` to a handler that doesn't write localStorage.
+  describe('transient close (does not mark seen)', () => {
+    it('calls onClose when the close button is pressed', () => {
+      const onClose = jest.fn();
+      const onAcknowledge = jest.fn();
+      render(<GetStartedModal isOpen onClose={onClose} onAcknowledge={onAcknowledge} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /close get started guide/i }));
-    expect(handleClose).toHaveBeenCalledTimes(1);
+      fireEvent.click(screen.getByRole('button', { name: /close get started guide/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onAcknowledge).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose on Escape', () => {
+      const onClose = jest.fn();
+      const onAcknowledge = jest.fn();
+      render(<GetStartedModal isOpen onClose={onClose} onAcknowledge={onAcknowledge} />);
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onAcknowledge).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClose on Escape when the modal is closed', () => {
+      const onClose = jest.fn();
+      render(
+        <GetStartedModal isOpen={false} onClose={onClose} onAcknowledge={jest.fn()} />,
+      );
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when the backdrop is clicked', () => {
+      const onClose = jest.fn();
+      const onAcknowledge = jest.fn();
+      render(
+        <GetStartedModal isOpen onClose={onClose} onAcknowledge={onAcknowledge} />,
+      );
+
+      // Modal renders via Portal, so query document.body. The backdrop
+      // is the only aria-hidden div in the modal tree.
+      const backdrop = document.body.querySelector('div[aria-hidden="true"]');
+      expect(backdrop).not.toBeNull();
+      fireEvent.click(backdrop!);
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onAcknowledge).not.toHaveBeenCalled();
+    });
+  });
+
+  // Acknowledged dismiss — the only path that marks the guide as seen.
+  it('calls onAcknowledge (not onClose) when "Got it" is pressed', () => {
+    const onClose = jest.fn();
+    const onAcknowledge = jest.fn();
+    render(<GetStartedModal isOpen onClose={onClose} onAcknowledge={onAcknowledge} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   // Contract: the UI/UX audit skill (.claude/skills/ui-ux-audit/audit.mjs)
@@ -48,7 +103,7 @@ describe('GetStartedModal', () => {
   // label genuinely needs to change, update the suppressor in audit.mjs
   // in the same PR.
   it('exposes the exact aria-label the audit script depends on', () => {
-    render(<GetStartedModal isOpen onClose={jest.fn()} />);
+    render(<GetStartedModal isOpen onClose={jest.fn()} onAcknowledge={jest.fn()} />);
     const btn = screen.getByLabelText('Close get started guide');
     expect(btn).toBeInTheDocument();
     expect(btn.tagName).toBe('BUTTON');


### PR DESCRIPTION
## Summary

Co-lands two related findings from RFC 0002 because shipping **M5**
alone would make **H4** worse.

### H4 — seen-flag set on every dismissal

`App.tsx:80-83` `handleCloseGetStarted` called `markGetStartedSeen()`
*unconditionally*, so any dismiss path permanently silenced the modal
for that user, with no in-app recovery. Once M5 added Esc and backdrop
dismiss, an accidental Esc on first load would have written
`localStorage.hindsight.get-started.<email>` and the guide would never
appear again.

**Fix:** split the handler. Only the explicit **Got it** button calls
`markGetStartedSeen()` (acknowledged). X, Escape, backdrop are
transient closes and don't write storage.

### M5 — no Esc handler; backdrop dismiss broken

The GetStarted modal had no `keydown` listener. Its backdrop *click
handler* existed but was on the outer flex container — and the visible
backdrop is an absolutely-positioned sibling that intercepts clicks
visually. So `event.target !== event.currentTarget` was always true
and the close never fired.

**Fix:** move the click handler onto the actual backdrop div, add Esc
via `useEffect` matching the AboutModal pattern.

The audit script (`.claude/skills/ui-ux-audit/audit.mjs:283-302`,
landing in PR #51) probes both bugs as findings. Both reports will
disappear from `findings.json` on the next audit run.

## API change

`GetStartedModal` gains a required `onAcknowledge` prop alongside
`onClose`. Required (not optional) so future call sites are forced to
think about the seen-marking semantics — no quiet default that hides
the bug.

```ts
interface GetStartedModalProps {
  isOpen: boolean;
  onClose: () => void;        // transient — no localStorage write
  onAcknowledge: () => void;  // explicit ack — writes localStorage
}
```

## Audit-script invariant preserved

The audit suppressor clicks the close button via
`button[aria-label="Close get started guide"]`. Post-fix that click
calls `onClose` (transient) — modal closes for the duration of the
audit run, but doesn't mark seen permanently. That's actually *better*
for the audit: idempotent across runs.

The aria-label contract test from PR #51 is included in this PR's test
file too (with the new `onAcknowledge` prop) so the lock stays in
place if PRs land out of order.

## Test plan

- [x] `npm run test -- --runInBand` — 261 / 261 pass (256 staging
  baseline + 5 new tests).
- [x] New tests cover: X button calls onClose; Escape calls onClose;
  Escape with closed modal does nothing; backdrop click calls onClose;
  "Got it" calls onAcknowledge (not onClose); aria-label contract.
- [x] All existing tests updated to pass `onAcknowledge={jest.fn()}` —
  TypeScript enforces the new required prop.
- [x] Typecheck delta: 0 new errors.
- [x] Lint delta: +1 (test-file `backdrop!` non-null assertion — same
  class as the 170 pre-existing TS-construct-fails-JS-parser errors).

## Coordination with PR #51

PR #51 adds the audit skill and a contract test asserting the
`Close get started guide` aria-label. If H4+M5 lands first, #51's
contract test will need a tiny rebase (add `onAcknowledge={jest.fn()}`
to its render call). I copied the contract test into this PR's test
file too so the lock stays whichever PR lands first. On rebase, drop
the duplicate from #51.

## Out of scope

- Making the audit script's suppressor use the new backdrop dismiss
  instead of the X button. The X-button path is more robust (works on
  pages where the modal renders without overlay positioning).
- Adding a "Don't show again" checkbox (rev 1 idea — explicitly punted
  in RFC 0002 rev 2 as scope creep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)