### PR TITLE
fix: restyle AddKeyword + AddMemoryBlock modals with Tailwind (RFC 0002 H1+H2 — modals half)

### DIFF
--- a/apps/hindsight-dashboard/src/components/AddKeywordModal.tsx
+++ b/apps/hindsight-dashboard/src/components/AddKeywordModal.tsx
@@ -1,9 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Portal from './Portal';
+import Button from './Button';
 import memoryService from '../api/memoryService';
 import { useOrg } from '../context/OrgContext';
 
-interface AddKeywordModalProps { isOpen: boolean; onClose: () => void; onSuccess?: () => void; }
+interface AddKeywordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
 
 const AddKeywordModal: React.FC<AddKeywordModalProps> = ({ isOpen, onClose, onSuccess }) => {
   const [keyword, setKeyword] = useState<string>('');
@@ -13,50 +18,124 @@ const AddKeywordModal: React.FC<AddKeywordModalProps> = ({ isOpen, onClose, onSu
   const [snapshotScope, setSnapshotScope] = useState<'personal' | 'organization' | 'public'>('personal');
   const [snapshotOrgId, setSnapshotOrgId] = useState<string | null>(null);
 
-  useEffect(() => { if (isOpen) { setKeyword(''); setError(null); try { setSnapshotScope((activeScope as any) || (sessionStorage.getItem('ACTIVE_SCOPE') as any) || 'personal'); setSnapshotOrgId(activeOrgId || sessionStorage.getItem('ACTIVE_ORG_ID')); } catch {} } }, [isOpen]);
+  useEffect(() => {
+    if (!isOpen) return;
+    setKeyword('');
+    setError(null);
+    try {
+      setSnapshotScope((activeScope as any) || (sessionStorage.getItem('ACTIVE_SCOPE') as any) || 'personal');
+      setSnapshotOrgId(activeOrgId || sessionStorage.getItem('ACTIVE_ORG_ID'));
+    } catch {}
+  }, [isOpen]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault(); e.stopPropagation();
-    if (!keyword.trim()) { setError('Keyword cannot be empty'); return; }
-    setLoading(true); setError(null);
+    e.preventDefault();
+    e.stopPropagation();
+    if (!keyword.trim()) {
+      setError('Keyword cannot be empty');
+      return;
+    }
+    setLoading(true);
+    setError(null);
     try {
       await memoryService.createKeyword(
         { keyword: keyword.trim() },
-        { scopeOverride: { scope: snapshotScope, organizationId: snapshotOrgId || undefined } }
+        { scopeOverride: { scope: snapshotScope, organizationId: snapshotOrgId || undefined } },
       );
-      setKeyword(''); onClose(); onSuccess?.();
+      setKeyword('');
+      onClose();
+      onSuccess?.();
     } catch (err) {
       console.error('Failed to create keyword:', err);
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError('Failed to create keyword: ' + message);
-    } finally { setLoading(false); }
+    } finally {
+      setLoading(false);
+    }
   };
-
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => { e.stopPropagation(); if (e.target === e.currentTarget) { onClose(); } };
-  const handleModalContentClick = (e: React.MouseEvent<HTMLDivElement>) => { e.stopPropagation(); };
 
   if (!isOpen) return null;
 
   return (
     <Portal>
-    <div className="dialog-overlay" onClick={handleBackdropClick}>
-      <div className="dialog-box" onClick={handleModalContentClick}>
-        <h2>Add New Keyword</h2>
-        <div className="dialog-content">
-          {error && <p className="error-message" data-testid="modal-error">{error}</p>}
+      <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+        <div
+          className="absolute inset-0 bg-gray-900/50"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+        <div
+          className="relative w-full max-w-md bg-white rounded-2xl shadow-2xl overflow-hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="add-keyword-title"
+        >
+          <header className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <h2 id="add-keyword-title" className="text-lg font-semibold text-gray-900">
+              Add New Keyword
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M6 18L18 6" />
+              </svg>
+            </button>
+          </header>
+
           <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label htmlFor="keyword">Keyword *</label>
-              <input id="keyword" name="keyword" type="text" value={keyword} onChange={(e) => setKeyword(e.target.value)} required placeholder="Enter keyword text" data-testid="keyword-input" disabled={loading} autoFocus />
+            <div className="px-6 py-5 space-y-4">
+              {error && (
+                <p
+                  className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  data-testid="modal-error"
+                >
+                  {error}
+                </p>
+              )}
+              <div className="space-y-1.5">
+                <label htmlFor="keyword" className="block text-sm font-medium text-gray-700">
+                  Keyword <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="keyword"
+                  name="keyword"
+                  type="text"
+                  value={keyword}
+                  onChange={(e) => setKeyword(e.target.value)}
+                  required
+                  placeholder="Enter keyword text"
+                  data-testid="keyword-input"
+                  disabled={loading}
+                  autoFocus
+                  className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                />
+              </div>
             </div>
-            <div className="dialog-actions">
-              <button type="button" onClick={onClose} disabled={loading} data-testid="cancel-button">Cancel</button>
-              <button type="submit" disabled={loading || !keyword.trim()} data-testid="submit-button">{loading ? 'Creating...' : 'Create Keyword'}</button>
-            </div>
+
+            <footer className="flex justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200">
+              <Button
+                variant="secondary"
+                onClick={onClose}
+                disabled={loading}
+                data-testid="cancel-button"
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={loading || !keyword.trim()}
+                data-testid="submit-button"
+              >
+                {loading ? 'Creating...' : 'Create Keyword'}
+              </Button>
+            </footer>
           </form>
         </div>
       </div>
-    </div>
     </Portal>
   );
 };

--- a/apps/hindsight-dashboard/src/components/AddMemoryBlockModal.tsx
+++ b/apps/hindsight-dashboard/src/components/AddMemoryBlockModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Portal from './Portal';
+import Button from './Button';
 import memoryService from '../api/memoryService';
 import agentService from '../api/agentService';
 import notificationService from '../services/notificationService';
@@ -150,168 +151,214 @@ const AddMemoryBlockModal: React.FC<AddMemoryBlockModalProps> = ({ isOpen, onClo
     }
   };
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>): void => {
-    // Prevent event bubbling and ensure we only close on backdrop click
-    e.stopPropagation();
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
-  const handleModalContentClick = (e: React.MouseEvent<HTMLDivElement>): void => {
-    // Prevent clicks inside the modal from closing it
-    e.stopPropagation();
-  };
-
   if (!isOpen) return null;
+
+  const inputClasses =
+    'block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:bg-gray-100 disabled:cursor-not-allowed';
+  const labelClasses = 'block text-sm font-medium text-gray-700';
 
   return (
     <Portal>
-    <div className="dialog-overlay" onClick={handleBackdropClick}>
-      <div className="dialog-box" onClick={handleModalContentClick}>
-        <h2>Add New Memory Block</h2>
-        <div className="dialog-content">
-          {error && <p className="error-message" data-testid="modal-error">{error}</p>}
+      <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+        <div
+          className="absolute inset-0 bg-gray-900/50"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+        <div
+          className="relative w-full max-w-2xl bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="add-memory-block-title"
+        >
+          <header className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <h2 id="add-memory-block-title" className="text-lg font-semibold text-gray-900">
+              Add New Memory Block
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M6 18L18 6" />
+              </svg>
+            </button>
+          </header>
 
-          <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label htmlFor="content">Content *</label>
-              <textarea
-                id="content"
-                name="content"
-                value={formData.content}
-                onChange={handleInputChange}
-                required
-                placeholder="Enter the main content of the memory block"
-                rows={4}
-                data-testid="content-input"
-                disabled={loading}
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="lessons_learned">Lessons Learned *</label>
-              <textarea
-                id="lessons_learned"
-                name="lessons_learned"
-                value={formData.lessons_learned}
-                onChange={handleInputChange}
-                required
-                placeholder="What lessons were learned from this experience?"
-                rows={3}
-                data-testid="lessons-input"
-                disabled={loading}
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="errors">Errors (Optional)</label>
-              <textarea
-                id="errors"
-                name="errors"
-                value={formData.errors}
-                onChange={handleInputChange}
-                placeholder="Any errors or issues encountered"
-                rows={2}
-                data-testid="errors-input"
-                disabled={loading}
-              />
-            </div>
-
-            <div className="form-row">
-              <div className="form-group">
-                <label htmlFor="agent_id">Agent ID</label>
-                <select
-                  id="agent_id"
-                  name="agent_id"
-                  value={formData.agent_id}
-                  onChange={handleInputChange}
-                  data-testid="agent-select"
-                  disabled={loading}
+          <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
+            <div className="px-6 py-5 space-y-5 overflow-y-auto">
+              {error && (
+                <p
+                  className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  data-testid="modal-error"
                 >
-                  <option value="">Select an agent (optional)</option>
-                  {availableAgents.map(agent => (
-                    <option key={agent.id} value={agent.id}>
-                      {agent.name || agent.id}
-                    </option>
-                  ))}
-                </select>
-              </div>
+                  {error}
+                </p>
+              )}
 
-              <div className="form-group">
-                <label htmlFor="conversation_id">Conversation ID</label>
-                <input
-                  type="text"
-                  id="conversation_id"
-                  name="conversation_id"
-                  value={formData.conversation_id}
+              <div className="space-y-1.5">
+                <label htmlFor="content" className={labelClasses}>
+                  Content <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="content"
+                  name="content"
+                  value={formData.content}
                   onChange={handleInputChange}
-                  placeholder="Optional conversation ID"
-                  data-testid="conversation-input"
+                  required
+                  placeholder="Enter the main content of the memory block"
+                  rows={4}
+                  data-testid="content-input"
                   disabled={loading}
-                />
-              </div>
-            </div>
-
-            <div className="form-row">
-              <div className="form-group">
-                <label htmlFor="feedback_score">Feedback Score</label>
-                <input
-                  type="number"
-                  id="feedback_score"
-                  name="feedback_score"
-                  value={formData.feedback_score}
-                  onChange={handleInputChange}
-                  min="0"
-                  max="100"
-                  placeholder="0-100"
-                  data-testid="feedback-input"
-                  disabled={loading}
+                  className={inputClasses}
                 />
               </div>
 
-              <div className="form-group">
-                <label htmlFor="keywords">Keywords</label>
-                <select
-                  id="keywords"
-                  name="keywords"
-                  multiple
-                  value={formData.keywords}
-                  onChange={handleKeywordChange}
-                  data-testid="keywords-select"
+              <div className="space-y-1.5">
+                <label htmlFor="lessons_learned" className={labelClasses}>
+                  Lessons Learned <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="lessons_learned"
+                  name="lessons_learned"
+                  value={formData.lessons_learned}
+                  onChange={handleInputChange}
+                  required
+                  placeholder="What lessons were learned from this experience?"
+                  rows={3}
+                  data-testid="lessons-input"
                   disabled={loading}
-                >
-                  {availableKeywords.map(keyword => (
-                    <option key={keyword} value={keyword}>
-                      {keyword}
-                    </option>
-                  ))}
-                </select>
-                <small className="form-help">Hold Ctrl/Cmd to select multiple keywords</small>
+                  className={inputClasses}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label htmlFor="errors" className={labelClasses}>
+                  Errors (Optional)
+                </label>
+                <textarea
+                  id="errors"
+                  name="errors"
+                  value={formData.errors}
+                  onChange={handleInputChange}
+                  placeholder="Any errors or issues encountered"
+                  rows={2}
+                  data-testid="errors-input"
+                  disabled={loading}
+                  className={inputClasses}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <label htmlFor="agent_id" className={labelClasses}>
+                    Agent ID
+                  </label>
+                  <select
+                    id="agent_id"
+                    name="agent_id"
+                    value={formData.agent_id}
+                    onChange={handleInputChange}
+                    data-testid="agent-select"
+                    disabled={loading}
+                    className={inputClasses}
+                  >
+                    <option value="">Select an agent (optional)</option>
+                    {availableAgents.map(agent => (
+                      <option key={agent.id} value={agent.id}>
+                        {agent.name || agent.id}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="conversation_id" className={labelClasses}>
+                    Conversation ID
+                  </label>
+                  <input
+                    type="text"
+                    id="conversation_id"
+                    name="conversation_id"
+                    value={formData.conversation_id}
+                    onChange={handleInputChange}
+                    placeholder="Optional conversation ID"
+                    data-testid="conversation-input"
+                    disabled={loading}
+                    className={inputClasses}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <label htmlFor="feedback_score" className={labelClasses}>
+                    Feedback Score
+                  </label>
+                  <input
+                    type="number"
+                    id="feedback_score"
+                    name="feedback_score"
+                    value={formData.feedback_score}
+                    onChange={handleInputChange}
+                    min="0"
+                    max="100"
+                    placeholder="0-100"
+                    data-testid="feedback-input"
+                    disabled={loading}
+                    className={inputClasses}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="keywords" className={labelClasses}>
+                    Keywords
+                  </label>
+                  <select
+                    id="keywords"
+                    name="keywords"
+                    multiple
+                    value={formData.keywords}
+                    onChange={handleKeywordChange}
+                    data-testid="keywords-select"
+                    disabled={loading}
+                    className={`${inputClasses} min-h-[5rem]`}
+                  >
+                    {availableKeywords.map(keyword => (
+                      <option key={keyword} value={keyword}>
+                        {keyword}
+                      </option>
+                    ))}
+                  </select>
+                  <small className="block text-xs text-gray-500">
+                    Hold Ctrl/Cmd to select multiple keywords
+                  </small>
+                </div>
               </div>
             </div>
 
-            <div className="dialog-actions">
-              <button
-                type="button"
+            <footer className="flex justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200">
+              <Button
+                variant="secondary"
                 onClick={onClose}
                 disabled={loading}
                 data-testid="cancel-button"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 disabled={loading}
                 data-testid="submit-button"
               >
                 {loading ? 'Creating...' : 'Create Memory Block'}
-              </button>
-            </div>
+              </Button>
+            </footer>
           </form>
         </div>
       </div>
-    </div>
     </Portal>
   );
 };

--- a/apps/hindsight-dashboard/src/components/Button.tsx
+++ b/apps/hindsight-dashboard/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type ButtonVariant = 'primary';
+type ButtonVariant = 'primary' | 'secondary';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
@@ -9,6 +9,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   primary:
     'bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
+  secondary:
+    'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2',
 };
 
 const BASE_CLASSES =

--- a/apps/hindsight-dashboard/src/components/__tests__/Button.test.tsx
+++ b/apps/hindsight-dashboard/src/components/__tests__/Button.test.tsx
@@ -37,4 +37,15 @@ describe('Button (primitive)', () => {
     expect(btn).toHaveClass('bg-blue-600');
     expect(btn).toHaveClass('ml-auto');
   });
+
+  it('renders the secondary variant with the outlined token', () => {
+    render(<Button variant="secondary">Cancel</Button>);
+    const btn = screen.getByRole('button', { name: 'Cancel' });
+    expect(btn).toHaveClass('border');
+    expect(btn).toHaveClass('border-gray-300');
+    expect(btn).toHaveClass('bg-white');
+    expect(btn).toHaveClass('text-gray-700');
+    // Secondary must NOT carry the primary's filled-blue styling.
+    expect(btn).not.toHaveClass('bg-blue-600');
+  });
 });


### PR DESCRIPTION
## Summary

This is the **modals half** of the H1+H2 legacy-class restyle from
RFC 0002. Targets `integration/rfc-0002-batch-1` rather than `staging`
to keep CI off until the whole batch is ready (per the established
batch-1 workflow).

`AddKeywordModal` and `AddMemoryBlockModal` were entirely unstyled —
their wrappers used legacy classes (`dialog-overlay`, `dialog-box`,
`dialog-content`, `form-group`, `dialog-actions`, `form-row`) that no
longer have any CSS rules under Tailwind v4. Both modals now use the
same Portal/backdrop/header/body/footer pattern as `AboutModal` and
`GetStartedModal`.

The **pages half** (Consolidation, Pruning, MemoryBlockList,
ConsolidationSuggestionDetail) is deferred to a follow-up PR — those
files have extra dead-code complications (duplicate empty-state
markup, mixed legacy/modern paths) that deserve separate review.

## What changed

**`<Button>` gains a `secondary` variant.** RFC 0002 M6 anticipated
this exact moment: "secondary/danger when H1/H2 actually need them".
The Cancel buttons in both modals are the consumers. The variant is
outlined gray (`border-gray-300 bg-white text-gray-700 hover:bg-gray-50`)
matching modern dashboard convention. New unit test locks the token in.

**AddKeywordModal** — full rewrite. Single-field form, simple submit
flow. Backdrop click and X button both call `onClose` (matches the
H4+M5 fix shape, where the click handler is on the absolute backdrop
sibling, not the outer wrapper).

**AddMemoryBlockModal** — full rewrite of the modal chrome + form
layout. Top-level form fields stack vertically; the four optional
fields (Agent ID, Conversation ID, Feedback Score, Keywords) use
`grid grid-cols-1 sm:grid-cols-2 gap-4` so they're paired on tablet+,
stacked on mobile. Body is `max-h-[90vh]` with internal `overflow-y-auto`
so long content doesn't push the viewport.

**Form-field token** — both modals share two constants:

```
const inputClasses = 'block w-full rounded-md border border-gray-300
  px-3 py-2 text-sm focus:border-blue-500 focus:outline-none
  focus:ring-2 focus:ring-blue-500/30 disabled:bg-gray-100
  disabled:cursor-not-allowed';
const labelClasses = 'block text-sm font-medium text-gray-700';
```

Defined locally per file for now (avoiding premature `<Input>` /
`<FormField>` primitives). Will promote to shared primitives if H1/H2
pages need them too.

## What's preserved

- All `data-testid`s (`cancel-button`, `submit-button`, `content-input`,
  `lessons-input`, `errors-input`, `agent-select`, `conversation-input`,
  `feedback-input`, `keywords-select`, `keyword-input`, `modal-error`).
- All form behavior: required fields, scope-snapshot logic at open,
  notification on success, error rendering on failure, autoFocus on
  the keyword input.
- Submit-button is now `<Button type="submit">` so the form's submit
  flow continues to work without an explicit click handler.

## Test plan

- [x] `npm run test -- --runInBand` — 268 / 268 (was 267; +1 from new
  Button secondary variant test).
- [x] Lint delta: 0 new errors over `integration/rfc-0002-batch-1`
  baseline (173).
- [x] Typecheck delta: 0 new errors over baseline (206).
- [x] No existing tests touched these modals directly; tests that
  consume them via parent components (MemoryBlocksPage,
  KeywordManager) continue to pass.
- [ ] Reviewer to verify modals visually after `start_hindsight.sh`:
  open `/keywords` → "Add Keyword"; open `/memory-blocks` → "Add Memory
  Block". Compare against the next audit run's screenshots.

## Out of scope (deferred to H1+H2 — pages PR)

- `MemoryBlockList`'s legacy `memory-block-list-container` wrapper.
- `ConsolidationSuggestions`' duplicate empty-state implementations
  (legacy + modern coexisting; needs design decision on which survives).
- `ConsolidationSuggestionDetail`'s "Reusing container style" comment
  — actual style needs to land too.
- `PruningSuggestions`' `pruning-params-section` + `param-hint` rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)