### PR TITLE
fix: restyle MemoryBlockList + Consolidation* + Pruning pages (RFC 0002 H1+H2 — pages half)

### DIFF
--- a/apps/hindsight-dashboard/src/components/ConsolidationSuggestionDetail.tsx
+++ b/apps/hindsight-dashboard/src/components/ConsolidationSuggestionDetail.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getConsolidationSuggestionById, validateConsolidationSuggestion, rejectConsolidationSuggestion } from '../api/memoryService';
-import memoryService from '../api/memoryService'; // To fetch original memory blocks
+import memoryService from '../api/memoryService';
 import { UIMemoryBlock } from '../types/domain';
+import Button from './Button';
 
 interface ConsolidationSuggestion {
   suggestion_id: string;
@@ -36,7 +37,7 @@ const ConsolidationSuggestionDetail: React.FC = () => {
         const fetchedOriginalMemories: UIMemoryBlock[] = await Promise.all(
           suggestionData.original_memory_ids.map((memoryId: string) => memoryService.getMemoryBlockById(memoryId))
         );
-        setOriginalMemories(fetchedOriginalMemories.filter(Boolean)); // Filter out any null/undefined results
+        setOriginalMemories(fetchedOriginalMemories.filter(Boolean));
       }
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';
@@ -53,11 +54,10 @@ const ConsolidationSuggestionDetail: React.FC = () => {
 
   const handleValidate = async (): Promise<void> => {
     if (!id) return;
-
     try {
       await validateConsolidationSuggestion(id);
       alert('Suggestion validated successfully.');
-      navigate('/consolidation-suggestions'); // Go back to list after action
+      navigate('/consolidation-suggestions');
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';
       alert(`Failed to validate suggestion. Error: ${errorMessage}`);
@@ -67,11 +67,10 @@ const ConsolidationSuggestionDetail: React.FC = () => {
 
   const handleReject = async (): Promise<void> => {
     if (!id) return;
-
     try {
       await rejectConsolidationSuggestion(id);
       alert('Suggestion rejected successfully.');
-      navigate('/consolidation-suggestions'); // Go back to list after action
+      navigate('/consolidation-suggestions');
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';
       alert(`Failed to reject suggestion. Error: ${errorMessage}`);
@@ -79,51 +78,100 @@ const ConsolidationSuggestionDetail: React.FC = () => {
     }
   };
 
-  if (loading) return <p className="loading-message">Loading suggestion details...</p>;
-  if (error) return <p className="error-message">Error: {error}</p>;
-  if (!suggestion) return <p className="empty-state-message">Suggestion not found.</p>;
+  if (loading) {
+    return (
+      <p className="px-6 py-4 text-sm text-gray-500" data-testid="loading-message">
+        Loading suggestion details...
+      </p>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        className="mx-6 my-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        data-testid="error-message"
+      >
+        Error: {error}
+      </p>
+    );
+  }
+  if (!suggestion) {
+    return (
+      <p className="px-6 py-4 text-sm text-gray-500" data-testid="empty-state-message">
+        Suggestion not found.
+      </p>
+    );
+  }
 
   return (
-    <div className="memory-block-list-container"> {/* Reusing container style */}
-      <div className="data-table-container"> {/* Reusing card style */}
-        <h2>Consolidation Suggestion Details</h2>
-        <div className="detail-section">
-          <h3>Suggested Content</h3>
-          <p>{suggestion.suggested_content}</p>
-        </div>
+    <div className="flex flex-col gap-4 p-4 sm:p-6">
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
+        <h2 className="text-xl font-semibold text-gray-900">Consolidation Suggestion Details</h2>
 
-        <div className="detail-section">
-          <h3>Original Memories ({originalMemories.length})</h3>
+        <section className="space-y-2">
+          <h3 className="text-sm font-medium text-gray-700">Suggested Content</h3>
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{suggestion.suggested_content}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-medium text-gray-700">
+            Original Memories ({originalMemories.length})
+          </h3>
           {originalMemories.length > 0 ? (
-            <div className="original-memories-list">
+            <div className="space-y-3">
               {originalMemories.map((memory, index) => (
-                <div key={memory.id} className="memory-block-item">
-                  <h4>Memory Block {index + 1}: {memory.id.slice(0, 8)}...</h4>
-                  <p><strong>Lessons Learned:</strong> {memory.lessons_learned}</p>
-                  <p><strong>Content:</strong> {memory.content}</p>
-                  <p><strong>Keywords:</strong> {memory.keywords ? memory.keywords.map((k: any) => k.keyword_text || k.keyword).join(', ') : 'None'}</p>
-                  <p><strong>Created At:</strong> {memory.created_at ? new Date(memory.created_at).toLocaleString() : 'Unknown'}</p>
-                  {/* Add more details as needed */}
-                  <button onClick={() => navigate(`/memory-blocks/${memory.id}`)} className="action-icon-button view-edit-button" title="View Original Memory Block">
-                    👁️ View Original
-                  </button>
+                <div
+                  key={memory.id}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-4 space-y-2"
+                >
+                  <h4 className="text-sm font-semibold text-gray-800">
+                    Memory Block {index + 1}: {memory.id.slice(0, 8)}…
+                  </h4>
+                  <p className="text-sm text-gray-700">
+                    <strong className="font-medium text-gray-900">Lessons Learned:</strong>{' '}
+                    {memory.lessons_learned}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <strong className="font-medium text-gray-900">Content:</strong> {memory.content}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <strong className="font-medium text-gray-900">Keywords:</strong>{' '}
+                    {memory.keywords ? memory.keywords.map((k: any) => k.keyword_text || k.keyword).join(', ') : 'None'}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <strong className="font-medium text-gray-900">Created At:</strong>{' '}
+                    {memory.created_at ? new Date(memory.created_at).toLocaleString() : 'Unknown'}
+                  </p>
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate(`/memory-blocks/${memory.id}`)}
+                    title="View Original Memory Block"
+                  >
+                    View Original
+                  </Button>
                 </div>
               ))}
             </div>
           ) : (
-            <p>No original memories found for this suggestion.</p>
+            <p className="text-sm text-gray-500">No original memories found for this suggestion.</p>
           )}
-        </div>
+        </section>
 
-        <div className="detail-actions">
+        <footer className="flex flex-wrap gap-3 pt-4 border-t border-gray-200">
           {suggestion.status === 'pending' && (
             <>
-              <button onClick={handleValidate} className="add-button">Validate Suggestion</button>
-              <button onClick={handleReject} className="remove-button">Reject Suggestion</button>
+              <Button onClick={handleValidate}>Validate Suggestion</Button>
+              <Button variant="secondary" onClick={handleReject}>Reject Suggestion</Button>
             </>
           )}
-          <button onClick={() => navigate('/consolidation-suggestions')} className="secondary-button">Back to Suggestions</button>
-        </div>
+          <Button
+            variant="secondary"
+            onClick={() => navigate('/consolidation-suggestions')}
+            className="ml-auto"
+          >
+            Back to Suggestions
+          </Button>
+        </footer>
       </div>
     </div>
   );

--- a/apps/hindsight-dashboard/src/components/ConsolidationSuggestions.tsx
+++ b/apps/hindsight-dashboard/src/components/ConsolidationSuggestions.tsx
@@ -6,6 +6,7 @@ import ConsolidationSuggestionModal from './ConsolidationSuggestionModal';
 import { useAuth } from '../context/AuthContext';
 import RefreshIndicator from './RefreshIndicator';
 import usePageHeader from '../hooks/usePageHeader';
+import Button from './Button';
 
 interface PaginationState {
   page: number;
@@ -175,15 +176,6 @@ const ConsolidationSuggestions: React.FC = () => {
     }
   };
 
-  const refreshData = (): void => {
-    if (featureDisabled) {
-      notificationService.showInfo('Feature coming soon');
-      return;
-    }
-    const abortController = new AbortController();
-    fetchSuggestions(abortController.signal);
-  };
-
   const handleValidate = async (suggestionId: string): Promise<void> => {
     try {
       const updatedSuggestion = await validateConsolidationSuggestion(suggestionId);
@@ -306,35 +298,51 @@ const ConsolidationSuggestions: React.FC = () => {
     );
   }
 
-  if (loading) return <p className="loading-message">Loading consolidation suggestions...</p>;
-  if (error) return <p className="error-message">Error: {error}</p>;
+  if (loading) {
+    return (
+      <p className="px-6 py-4 text-sm text-gray-500" data-testid="loading-message">
+        Loading consolidation suggestions...
+      </p>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        className="mx-6 my-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        data-testid="error-message"
+      >
+        Error: {error}
+      </p>
+    );
+  }
 
   return (
-    <div className="memory-block-list-container">
-      {/* Filter Controls - Always render these */}
-      <div className="bulk-actions-bar">
-        <button
+    <div className="flex flex-col gap-4 p-4 sm:p-6">
+      {/* Toolbar: bulk-delete + trigger + status filter. Always rendered. */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="secondary"
           onClick={handleDeleteSelected}
           disabled={selectedSuggestionIds.length === 0}
-          className="delete-selected-button"
         >
           Delete Selected ({selectedSuggestionIds.length})
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={handleTriggerConsolidation}
-          className={`add-button ${llmDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           disabled={llmDisabled}
           title={llmDisabled ? 'LLM features are currently disabled' : undefined}
         >
           Trigger Consolidation
-        </button>
-        <div className="filter-controls">
-          <label htmlFor="status-filter">Filter by Status:</label>
+        </Button>
+        <div className="ml-auto flex items-center gap-2">
+          <label htmlFor="status-filter" className="text-sm font-medium text-gray-700">
+            Filter by Status:
+          </label>
           <select
             id="status-filter"
             value={filterStatus}
             onChange={(e) => setFilterStatus(e.target.value)}
-            className="filter-select"
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
           >
             <option value="all">All</option>
             <option value="pending">Pending</option>
@@ -344,79 +352,7 @@ const ConsolidationSuggestions: React.FC = () => {
         </div>
       </div>
 
-      {/* Empty State Message when no filters are active and no results */}
-      {!loading && !error && suggestions.length === 0 && !areFiltersActive() && (
-        <div className="empty-state-message">
-          <p>No Consolidation Suggestions Found</p>
-          <p>
-            It looks like there are no consolidation suggestions in your system at the moment.
-            Try triggering the consolidation process manually if needed.
-          </p>
-          <button
-            onClick={handleTriggerConsolidation}
-            className={`add-button ${llmDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            disabled={llmDisabled}
-            title={llmDisabled ? 'LLM features are currently disabled' : undefined}
-          >
-            Trigger Consolidation
-          </button>
-        </div>
-      )}
-
-      {/* Empty State Message when filters are active but no results */}
-      {!loading && !error && suggestions.length === 0 && areFiltersActive() && (
-        <div className="empty-state-message">
-          <p>No Consolidation Suggestions Match Your Criteria</p>
-          <p>
-            We couldn't find any consolidation suggestions that match your current criteria.
-            Try adjusting your filters or clearing them to see all suggestions.
-          </p>
-          {/* No filters to clear yet, but keeping the structure for future */}
-        </div>
-      )}
-
-      {/* Suggestions Grid */}
-      {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-          {[...Array(6)].map((_, index) => (
-            <div key={index} className="bg-white p-6 rounded-xl shadow-sm border border-gray-200 animate-pulse">
-              <div className="flex justify-between items-start mb-4">
-                <div className="flex items-start gap-4 flex-1">
-                  <div className="bg-gray-200 p-3 rounded-lg flex-shrink-0 w-12 h-12"></div>
-                  <div className="flex-1">
-                    <div className="h-4 bg-gray-200 rounded w-32 mb-2"></div>
-                    <div className="h-3 bg-gray-200 rounded w-24"></div>
-                  </div>
-                </div>
-              </div>
-              <div className="space-y-3">
-                <div className="h-4 bg-gray-200 rounded w-full"></div>
-                <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                <div className="flex gap-2">
-                  <div className="h-6 bg-gray-200 rounded-full w-16"></div>
-                  <div className="h-6 bg-gray-200 rounded-full w-20"></div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      ) : error ? (
-        <div className="text-center py-12">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md mx-auto">
-            <svg className="w-12 h-12 text-red-500 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-            </svg>
-            <h3 className="text-lg font-medium text-red-800 mb-2">Error Loading Suggestions</h3>
-            <p className="text-red-700 mb-4">{error}</p>
-            <button
-              onClick={() => refreshData()}
-              className="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors"
-            >
-              Try Again
-            </button>
-          </div>
-        </div>
-      ) : suggestions.length === 0 ? (
+      {suggestions.length === 0 ? (
         <div className="text-center py-12">
           <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/apps/hindsight-dashboard/src/components/MemoryBlockList.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockList.tsx
@@ -11,6 +11,7 @@ import PaginationControls from './PaginationControls';
 import { UIMemoryBlock, UIMemoryKeyword } from '../types/domain';
 import { Agent } from '../api/agentService';
 import RefreshIndicator from './RefreshIndicator';
+import Button from './Button';
 import { isValidUuid } from '../utils/uuid';
 
 // Interfaces for component state
@@ -510,35 +511,39 @@ const MemoryBlockList: React.FC = () => {
   };
 
   if (loading) return (
-    <div className="loading-container" data-testid="loading-indicator">
-      <div className="loading-spinner">Loading memory blocks...</div>
+    <div className="px-6 py-4 text-sm text-gray-500" data-testid="loading-indicator">
+      Loading memory blocks…
     </div>
   );
 
-  // Display error message if there is one
   if (error) return (
-    <div className="error-message" data-testid="error-message">
+    <div
+      className="mx-6 my-4 flex items-start justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+      data-testid="error-message"
+    >
       <p>Error: {error}</p>
-      <button
-        className="error-dismiss-btn"
-        data-testid="dismiss-error"
+      <Button
+        variant="secondary"
         onClick={() => setError(null)}
+        data-testid="dismiss-error"
       >
         Dismiss
-      </button>
+      </Button>
     </div>
   );
 
   return (
-    <div className="memory-block-list-container">
-      {/* Success Message */}
+    <div className="flex flex-col gap-4 p-4 sm:p-6">
       {successMessage && (
-        <div className="success-message" data-testid="success-message">
-          <p>{successMessage}</p>
+        <div
+          className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700"
+          data-testid="success-message"
+        >
+          {successMessage}
         </div>
       )}
 
-      <div className="flex justify-end mb-4">
+      <div className="flex justify-end">
         <RefreshIndicator
           lastUpdated={lastUpdated}
           onRefresh={handleRefreshData}
@@ -546,29 +551,23 @@ const MemoryBlockList: React.FC = () => {
         />
       </div>
 
-      {/* Empty State Message */}
       {!loading && !error && memoryBlocks.length === 0 && !areFiltersActive() && (
-        <div className="empty-state-message">
-          <p>No Memory Blocks Found</p>
-          <p>
-            It looks like there are no memory blocks in your system.
-            Start by creating a new one!
-          </p>
-          {/* The "Add New Memory Block" button is now in App.js header */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 text-center text-sm text-gray-500">
+          <p className="font-medium text-gray-700 mb-1">No Memory Blocks Found</p>
+          <p>It looks like there are no memory blocks in your system. Start by creating a new one!</p>
         </div>
       )}
 
-      {/* Empty State Message when filters are active but no results */}
       {!loading && !error && memoryBlocks.length === 0 && areFiltersActive() && (
-        <div className="empty-state-message">
-          <p>No Memory Blocks Match Your Filters</p>
-          <p>
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 text-center text-sm text-gray-500">
+          <p className="font-medium text-gray-700 mb-1">No Memory Blocks Match Your Filters</p>
+          <p className="mb-4">
             We couldn't find any memory blocks that match your current search criteria.
             Try adjusting your filters or clearing them to see all memory blocks.
           </p>
-          <button onClick={resetFilters}>
+          <Button variant="secondary" onClick={resetFilters}>
             Clear Active Filters
-          </button>
+          </Button>
         </div>
       )}
 
@@ -609,27 +608,8 @@ const MemoryBlockList: React.FC = () => {
           )}
 
           {/* Memory Blocks Header - positioned above the table */}
-          <div className="memory-blocks-header" style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            padding: '16px 25px',
-            borderBottom: '1px solid #e0e0e0',
-            marginBottom: '0',
-            marginLeft: 'var(--content-margin)',
-            marginRight: 'var(--content-margin)',
-            width: 'var(--content-max-width)',
-            boxSizing: 'border-box',
-            minWidth: '0' // Allow flex items to shrink below their content size
-          }}>
-            {/* Total Count - Left Side */}
-            <div className="total-count" style={{
-              fontSize: '0.9em',
-              color: '#666',
-              fontWeight: '500',
-              flexShrink: 0, // Prevent shrinking
-              whiteSpace: 'nowrap'
-            }}>
+          <div className="flex items-center justify-between gap-3 border-b border-gray-200 px-6 py-4 min-w-0">
+            <div className="text-sm font-medium text-gray-600 whitespace-nowrap flex-shrink-0">
               {pagination.total_items > 0 && (
                 <span>
                   {pagination.total_items} memory block{pagination.total_items !== 1 ? 's' : ''} found
@@ -637,49 +617,21 @@ const MemoryBlockList: React.FC = () => {
               )}
             </div>
 
-            {/* Developer-only test controls */}
             {VITE_DEV_MODE && (
-              <div className="header-actions" style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-                flexShrink: 0,
-                marginLeft: 'auto'
-              }}>
+              <div className="flex items-center gap-1.5 flex-shrink-0 ml-auto">
                 <button
-                  className="test-save-button"
+                  type="button"
                   data-testid="save-button"
                   onClick={() => notificationService.showSuccess('Item saved successfully')}
-                  style={{
-                    backgroundColor: '#28a745',
-                    color: 'white',
-                    border: 'none',
-                    padding: '6px 10px',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontSize: '11px',
-                    whiteSpace: 'nowrap',
-                    flexShrink: 0
-                  }}
+                  className="rounded bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 whitespace-nowrap"
                 >
                   Test Save
                 </button>
-
                 <button
-                  className="test-invalid-button"
+                  type="button"
                   data-testid="invalid-action"
                   onClick={() => notificationService.showError('Invalid action performed')}
-                  style={{
-                    backgroundColor: '#dc3545',
-                    color: 'white',
-                    border: 'none',
-                    padding: '6px 10px',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontSize: '11px',
-                    whiteSpace: 'nowrap',
-                    flexShrink: 0
-                  }}
+                  className="rounded bg-red-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 whitespace-nowrap"
                 >
                   Test Error
                 </button>

--- a/apps/hindsight-dashboard/src/components/PruningSuggestions.tsx
+++ b/apps/hindsight-dashboard/src/components/PruningSuggestions.tsx
@@ -154,14 +154,16 @@ const PruningSuggestions: React.FC = () => {
     );
   }
 
+  // pruning_score semantics: lower = higher priority for pruning. So low
+  // scores warn (red), high scores are safe to keep (green).
   const scoreBadgeClass = (score: number | string | undefined): string => {
     if (score === undefined || score === null || score === '') {
       return 'bg-red-100 text-red-700 border-red-200';
     }
     const numScore = typeof score === 'string' ? parseFloat(score) : score;
-    if (numScore < 30) return 'bg-green-100 text-green-700 border-green-200';
+    if (numScore < 30) return 'bg-red-100 text-red-700 border-red-200';
     if (numScore < 70) return 'bg-amber-100 text-amber-700 border-amber-200';
-    return 'bg-red-100 text-red-700 border-red-200';
+    return 'bg-green-100 text-green-700 border-green-200';
   };
 
   const formatScore = (score: number | string | undefined): string => {

--- a/apps/hindsight-dashboard/src/components/PruningSuggestions.tsx
+++ b/apps/hindsight-dashboard/src/components/PruningSuggestions.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import memoryService from '../api/memoryService';
 import notificationService from '../services/notificationService';
 import { useAuth } from '../context/AuthContext';
+import Button from './Button';
 
 interface PruningSuggestion {
   memory_block_id: string;
@@ -153,164 +154,208 @@ const PruningSuggestions: React.FC = () => {
     );
   }
 
+  const scoreBadgeClass = (score: number | string | undefined): string => {
+    if (score === undefined || score === null || score === '') {
+      return 'bg-red-100 text-red-700 border-red-200';
+    }
+    const numScore = typeof score === 'string' ? parseFloat(score) : score;
+    if (numScore < 30) return 'bg-green-100 text-green-700 border-green-200';
+    if (numScore < 70) return 'bg-amber-100 text-amber-700 border-amber-200';
+    return 'bg-red-100 text-red-700 border-red-200';
+  };
+
+  const formatScore = (score: number | string | undefined): string => {
+    if (score === undefined || score === null || score === '') return 'N/A';
+    return (typeof score === 'string' ? parseFloat(score) : score).toFixed(2);
+  };
+
   return (
-    <div className="memory-block-list-container">
+    <div className="flex flex-col gap-4 p-4 sm:p-6">
       {/* Pruning Parameters */}
-      <div className="pruning-params-section">
-        <h3>Pruning Parameters</h3>
-        <div className="pruning-params-form">
-          <div className="form-group">
-            <label>Batch Size:</label>
+      <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-4">
+        <h3 className="text-base font-semibold text-gray-900">Pruning Parameters</h3>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="space-y-1.5">
+            <label htmlFor="batch_size" className="block text-sm font-medium text-gray-700">
+              Batch Size
+            </label>
             <input
+              id="batch_size"
               type="number"
               name="batch_size"
               value={pruningParams.batch_size}
               onChange={handleParamChange}
-              min="1"
-              max="100"
+              min={1}
+              max={100}
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
             />
-            <small className="param-hint">Number of memory blocks to evaluate in each batch (default: 50)</small>
+            <small className="block text-xs text-gray-500">
+              Number of memory blocks to evaluate in each batch (default: 50)
+            </small>
           </div>
-          <div className="form-group">
-            <label>Target Count:</label>
+          <div className="space-y-1.5">
+            <label htmlFor="target_count" className="block text-sm font-medium text-gray-700">
+              Target Count
+            </label>
             <input
+              id="target_count"
               type="number"
               name="target_count"
               value={pruningParams.target_count || ''}
               onChange={handleParamChange}
-              min="0"
+              min={0}
               placeholder="Leave empty for no limit"
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
             />
-            <small className="param-hint">Maximum number of blocks to suggest for pruning (default: 100, leave empty for no limit)</small>
+            <small className="block text-xs text-gray-500">
+              Maximum number of blocks to suggest for pruning (default: 100, leave empty for no limit)
+            </small>
           </div>
-          <div className="form-group">
-            <label>Max Iterations:</label>
+          <div className="space-y-1.5">
+            <label htmlFor="max_iterations" className="block text-sm font-medium text-gray-700">
+              Max Iterations
+            </label>
             <input
+              id="max_iterations"
               type="number"
               name="max_iterations"
               value={pruningParams.max_iterations}
               onChange={handleParamChange}
-              min="1"
-              max="100"
+              min={1}
+              max={100}
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
             />
-            <small className="param-hint">Maximum number of evaluation iterations to run (default: 10)</small>
+            <small className="block text-xs text-gray-500">
+              Maximum number of evaluation iterations to run (default: 10)
+            </small>
           </div>
-          <button
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
             onClick={handleRefresh}
             disabled={loading || llmDisabled}
-            style={llmDisabled ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
             title={llmDisabled ? 'LLM features are currently disabled' : undefined}
           >
-            {loading ? 'Loading...' : 'Generate Suggestions'}
-          </button>
+            {loading ? 'Loading…' : 'Generate Suggestions'}
+          </Button>
+          {llmDisabled && (
+            <p className="text-sm text-gray-500">LLM features are currently disabled. Generation is unavailable.</p>
+          )}
         </div>
-        {llmDisabled && (
-          <p className="text-sm text-gray-500 mt-3">LLM features are currently disabled. Generation is unavailable.</p>
-        )}
-      </div>
+      </section>
 
-      {/* Error Message */}
-      {error && <div className="error-message">{error}</div>}
+      {/* Error */}
+      {error && (
+        <div
+          className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+          data-testid="error-message"
+        >
+          {error}
+        </div>
+      )}
 
       {/* Empty State */}
       {!loading && suggestions.length === 0 && !error && (
-        <div className="empty-state-message">
-          <p>No pruning suggestions available</p>
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 text-center text-sm text-gray-500">
+          <p className="font-medium text-gray-700 mb-1">No pruning suggestions available</p>
           <p>Adjust the parameters and refresh to generate new suggestions.</p>
         </div>
       )}
 
       {/* Suggestions Table */}
       {suggestions.length > 0 && (
-        <div className="pruning-suggestions-container">
-          <div className="bulk-action-bar">
-            <div className="bulk-action-left">
+        <section className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          <header className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-3">
+            <div className="flex items-center gap-2 text-sm text-gray-700">
               <input
                 type="checkbox"
                 checked={selectedBlocks.length === suggestions.length && suggestions.length > 0}
                 onChange={handleSelectAll}
                 disabled={suggestions.length === 0}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                aria-label="Select all suggestions"
               />
               <span>{selectedBlocks.length} of {suggestions.length} selected</span>
             </div>
-            <div className="bulk-action-right">
-              <button 
-                onClick={handleConfirmPruning} 
-                disabled={selectedBlocks.length === 0 || confirming}
-                className="confirm-pruning-button"
-              >
-                {confirming ? 'Archiving...' : `Archive Selected (${selectedBlocks.length})`}
-              </button>
-            </div>
-          </div>
+            <Button
+              onClick={handleConfirmPruning}
+              disabled={selectedBlocks.length === 0 || confirming}
+            >
+              {confirming ? 'Archiving…' : `Archive Selected (${selectedBlocks.length})`}
+            </Button>
+          </header>
 
-          <div className="data-table-container">
-            <div className="data-table-header">
-              <div className="header-cell">Select</div>
-              <div className="header-cell">ID</div>
-              <div className="header-cell">Score</div>
-              <div className="header-cell">Reason</div>
-              <div className="header-cell">Content</div>
-              <div className="header-cell">Created</div>
-              <div className="header-cell">Actions</div>
-            </div>
-            
-            <div className="data-table-body">
-              {suggestions.map((block) => (
-                <div key={block.memory_block_id} className="data-table-row">
-                  <div className="data-cell">
-                    <input
-                      type="checkbox"
-                      checked={selectedBlocks.includes(block.memory_block_id)}
-                      onChange={() => handleSelectBlock(block.memory_block_id)}
-                    />
-                  </div>
-                  <div className="data-cell" title={block.memory_block_id}>
-                    {truncate(block.memory_block_id, 8)}
-                  </div>
-                  <div className="data-cell">
-                    <span className={`score-badge ${(() => {
-                      const score = block.pruning_score;
-                      if (score === undefined || score === null || score === '') return 'high';
-                      const numScore = typeof score === 'string' ? parseFloat(score) : score;
-                      return (numScore < 30) ? 'low' : (numScore < 70) ? 'medium' : 'high';
-                    })()}`}>
-                      {(() => {
-                        const score = block.pruning_score;
-                        return (score !== undefined && score !== null && score !== '') ? (typeof score === 'string' ? parseFloat(score) : score).toFixed(2) : 'N/A';
-                      })()}
-                    </span>
-                  </div>
-                  <div className="data-cell" title={block.rationale}>
-                    {truncate(block.rationale || 'No reason provided', 50)}
-                  </div>
-                  <div className="data-cell" title={block.content_preview}>
-                    {truncate(block.content_preview || '', 100)}
-                  </div>
-                  <div className="data-cell">
-                    {block.created_at ? new Date(block.created_at).toLocaleDateString() : 'N/A'}
-                  </div>
-                  <div className="data-cell">
-                    <button
-                      onClick={() => handleViewDetails(block.memory_block_id)}
-                      className="action-icon-button view-edit-button"
-                      title="View Details"
-                    >
-                      👁️
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th scope="col" className="px-4 py-2 w-10">Select</th>
+                  <th scope="col" className="px-4 py-2">ID</th>
+                  <th scope="col" className="px-4 py-2">Score</th>
+                  <th scope="col" className="px-4 py-2">Reason</th>
+                  <th scope="col" className="px-4 py-2">Content</th>
+                  <th scope="col" className="px-4 py-2">Created</th>
+                  <th scope="col" className="px-4 py-2 w-16 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {suggestions.map((block) => (
+                  <tr key={block.memory_block_id} className="hover:bg-gray-50">
+                    <td className="px-4 py-2">
+                      <input
+                        type="checkbox"
+                        checked={selectedBlocks.includes(block.memory_block_id)}
+                        onChange={() => handleSelectBlock(block.memory_block_id)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        aria-label={`Select suggestion ${block.memory_block_id.slice(0, 8)}`}
+                      />
+                    </td>
+                    <td className="px-4 py-2 font-mono text-xs text-gray-600" title={block.memory_block_id}>
+                      {truncate(block.memory_block_id, 8)}
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${scoreBadgeClass(block.pruning_score)}`}
+                      >
+                        {formatScore(block.pruning_score)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-700 max-w-xs truncate" title={block.rationale}>
+                      {truncate(block.rationale || 'No reason provided', 50)}
+                    </td>
+                    <td className="px-4 py-2 text-gray-700 max-w-md truncate" title={block.content_preview}>
+                      {truncate(block.content_preview || '', 100)}
+                    </td>
+                    <td className="px-4 py-2 text-gray-600 whitespace-nowrap">
+                      {block.created_at ? new Date(block.created_at).toLocaleDateString() : 'N/A'}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => handleViewDetails(block.memory_block_id)}
+                        className="inline-flex items-center justify-center rounded-md p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        title="View Details"
+                        aria-label="View Details"
+                      >
+                        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12s3.75-7.5 9.75-7.5 9.75 7.5 9.75 7.5-3.75 7.5-9.75 7.5S2.25 12 2.25 12z" />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        </div>
+        </section>
       )}
 
       {/* Loading State */}
       {loading && (
-        <div className="loading-message">
-          Generating pruning suggestions...
-        </div>
+        <p className="text-sm text-gray-500" data-testid="loading-message">
+          Generating pruning suggestions…
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Pages-half of H1+H2 (after #55 landed the modals half). Replaces the
dead legacy class names — which have no CSS rules under Tailwind v4
— with Tailwind tokens consistent with the rest of the dashboard.

Affected files:
- \`MemoryBlockList.tsx\`
- \`ConsolidationSuggestions.tsx\`
- \`ConsolidationSuggestionDetail.tsx\`
- \`PruningSuggestions.tsx\`

### Notable cleanup beyond pure restyle

- **\`ConsolidationSuggestions.tsx\`** had duplicate empty-state markup
  (legacy \`empty-state-message\` blocks above a modern grid path that
  already handled both with-filters and without-filters cases). Deleted.
- That same file also had unreachable skeleton/error branches in the
  post-toolbar ternary — the early \`if (loading) / if (error)\` returns
  above always short-circuited them. Deleted. Net: \`587 → 522\` lines.
- \`refreshData\` was only referenced from the deleted error branch;
  also removed.
- **\`MemoryBlockList.tsx\`** had an inline-styled \`memory-blocks-header\`
  using two CSS variables (\`--content-margin\`, \`--content-max-width\`)
  that don't exist anywhere. Replaced with a Tailwind flex row.
- **\`PruningSuggestions.tsx\`** parameter form is now a real \`grid
  md:grid-cols-3 gap-4\` (per the RFC's H2 prescription) and the
  hand-rolled \`data-table-*\` div grid is replaced with a real
  \`<table>\` for a11y / semantics. Score badge logic kept; class names
  swapped for color tokens.

### Preserved contracts

All \`data-testid\` attributes kept: \`dismiss-error\`, \`error-message\`,
\`success-message\`, \`loading-indicator\`, \`save-button\`,
\`invalid-action\`, \`loading-message\`, \`empty-state-message\`.

## Test plan

- [x] \`npm run typecheck\` (dashboard) — 2 pre-existing config errors,
      zero from this PR
- [x] \`npm test\` (dashboard) — 268/268 pass
- [x] \`npm run build\` — clean
- [ ] Manual smoke test: \`/memory-blocks\`, \`/consolidation-suggestions\`,
      \`/consolidation-suggestions/:id\`, \`/pruning-suggestions\` at
      desktop + mobile
- [ ] Refresh-while-data-loaded (verify the early-return loading path
      still shows briefly without breaking)

Refs RFC 0002 H1, H2.