### PR TITLE
fix: rewrite scroll model — document scrolls + sticky header (RFC 0002 M1)

### DIFF
--- a/apps/hindsight-dashboard/src/components/AboutModal.tsx
+++ b/apps/hindsight-dashboard/src/components/AboutModal.tsx
@@ -235,7 +235,7 @@ const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
           role="dialog"
           aria-modal="true"
           aria-labelledby="about-modal-title"
-          className="bg-white rounded-lg shadow-xl w-full mx-4 max-h-[90vh] overflow-y-auto max-w-2xl md:max-w-3xl"
+          className="bg-white rounded-lg shadow-xl w-full mx-4 max-h-[90vh] overflow-y-auto overscroll-contain max-w-2xl md:max-w-3xl"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between p-6 border-b border-gray-200">

--- a/apps/hindsight-dashboard/src/components/AddMemoryBlockModal.tsx
+++ b/apps/hindsight-dashboard/src/components/AddMemoryBlockModal.tsx
@@ -188,7 +188,7 @@ const AddMemoryBlockModal: React.FC<AddMemoryBlockModalProps> = ({ isOpen, onClo
           </header>
 
           <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
-            <div className="px-6 py-5 space-y-5 overflow-y-auto">
+            <div className="px-6 py-5 space-y-5 overflow-y-auto overscroll-contain">
               {error && (
                 <p
                   className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"

--- a/apps/hindsight-dashboard/src/components/AgentDetailsModal.tsx
+++ b/apps/hindsight-dashboard/src/components/AgentDetailsModal.tsx
@@ -143,7 +143,7 @@ const AgentDetailsModal: React.FC<AgentDetailsModalProps> = ({ isOpen, onClose, 
         </div>
 
         {/* Content - Scrollable */}
-        <div className="p-6 overflow-y-auto flex-1 min-h-0">
+        <div className="p-6 overflow-y-auto overscroll-contain flex-1 min-h-0">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-center">

--- a/apps/hindsight-dashboard/src/components/CompactionSettingsModal.tsx
+++ b/apps/hindsight-dashboard/src/components/CompactionSettingsModal.tsx
@@ -45,7 +45,7 @@ const CompactionSettingsModal: React.FC<CompactionSettingsModalProps> = ({
   if (!isOpen || !suggestion) return null;
 
   return createPortal(
-    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto h-full w-full z-50">
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto overscroll-contain h-full w-full z-50">
       <div className="relative top-20 mx-auto p-5 border w-11/12 max-w-2xl shadow-lg rounded-md bg-white">
         <div className="mt-3">
           {/* Header */}

--- a/apps/hindsight-dashboard/src/components/ConsolidationSuggestionModal.tsx
+++ b/apps/hindsight-dashboard/src/components/ConsolidationSuggestionModal.tsx
@@ -119,7 +119,7 @@ const ConsolidationSuggestionModal: React.FC<ConsolidationSuggestionModalProps> 
         </div>
 
         {/* Content - Scrollable */}
-        <div className="p-6 overflow-y-auto flex-1 min-h-0">
+        <div className="p-6 overflow-y-auto overscroll-contain flex-1 min-h-0">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-center">

--- a/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
+++ b/apps/hindsight-dashboard/src/components/GetStartedModal.tsx
@@ -605,7 +605,7 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({ isOpen, onClose, onAc
             </button>
           </header>
 
-          <div className="px-6 py-6 space-y-8 overflow-y-auto max-h-[80vh]">
+          <div className="px-6 py-6 space-y-8 overflow-y-auto overscroll-contain max-h-[80vh]">
             <section>
               <h3 className="text-lg font-semibold text-gray-900">Prepare your Hindsight workspace</h3>
               <ol className="mt-4 space-y-4 text-sm text-gray-700 list-decimal list-inside">

--- a/apps/hindsight-dashboard/src/components/KeywordManager.tsx
+++ b/apps/hindsight-dashboard/src/components/KeywordManager.tsx
@@ -530,7 +530,7 @@ const KeywordManager: React.FC = () => {
               </div>
             </div>
 
-            <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)]">
+            <div className="p-6 overflow-y-auto overscroll-contain max-h-[calc(90vh-120px)]">
               {loadingAssociations ? (
                 <div className="space-y-4">
                   {[...Array(3)].map((_, index) => (

--- a/apps/hindsight-dashboard/src/components/Layout.tsx
+++ b/apps/hindsight-dashboard/src/components/Layout.tsx
@@ -20,20 +20,21 @@ const Layout: React.FC<LayoutProps> = ({ children, title, onOpenAbout, onToggleD
   const handleSidebarCollapse = (collapsed: boolean) => setSidebarCollapsed(collapsed);
 
   return (
-    <div className="flex min-h-[100dvh] bg-gray-100 overflow-hidden">
-      <div className="fixed left-0 top-0 h-full z-10">
-        <Sidebar 
-          isOpen={sidebarOpen} 
-          onClose={closeSidebar} 
-          onCollapseChange={handleSidebarCollapse} 
-          onToggleDebugPanel={VITE_DEV_MODE ? onToggleDebugPanel : undefined} 
-        />
-      </div>
-      <div className={`flex-1 flex flex-col min-h-0 overflow-hidden ${sidebarCollapsed ? 'lg:ml-16 ml-0' : 'lg:ml-64 ml-0'}`}>
+    // No outer overflow-hidden / flex-column wrap: the document is now the
+    // scroller (RFC 0002 M1). Mobile address-bar tap, browser scroll
+    // restoration, and overscroll bounce all need the body to be the
+    // scrolling element. Sidebar stays fixed; main flows naturally.
+    <div className="min-h-[100dvh] bg-gray-100">
+      <Sidebar
+        isOpen={sidebarOpen}
+        onClose={closeSidebar}
+        onCollapseChange={handleSidebarCollapse}
+        onToggleDebugPanel={VITE_DEV_MODE ? onToggleDebugPanel : undefined}
+      />
+      <div className={sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'}>
         <MainContent
           title={title}
           toggleSidebar={toggleSidebar}
-          sidebarCollapsed={sidebarCollapsed}
           onOpenAbout={onOpenAbout}
           onOpenHelp={onOpenGetStarted}
         >

--- a/apps/hindsight-dashboard/src/components/MainContent.tsx
+++ b/apps/hindsight-dashboard/src/components/MainContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import UserAccountButton from './UserAccountButton';
 import OrganizationSwitcher from './OrganizationSwitcher';
 import NotificationBell from './NotificationBell';
@@ -9,22 +9,21 @@ import PageHeaderContext, { PageHeaderConfig } from '../context/PageHeaderContex
 interface MainContentProps {
   children: React.ReactNode;
   title: string;
-  sidebarCollapsed: boolean;
   toggleSidebar: () => void;
   onOpenAbout?: () => void;
   onOpenHelp?: () => void;
 }
 
-const MainContent: React.FC<MainContentProps> = ({ children, title, sidebarCollapsed, toggleSidebar, onOpenAbout, onOpenHelp }) => {
+const MainContent: React.FC<MainContentProps> = ({ children, title, toggleSidebar, onOpenAbout, onOpenHelp }) => {
   const { guest } = useAuth();
   const location = useLocation();
-  const scrollRef = useRef<HTMLDivElement | null>(null);
 
+  // Document is the scroller post-M1, so route changes scroll the window.
   useEffect(() => {
-    if (scrollRef.current) {
-      try { scrollRef.current.scrollTo({ top: 0, left: 0, behavior: 'smooth' }); } catch { scrollRef.current.scrollTop = 0; }
-    } else {
-      try { window.scrollTo({ top: 0, left: 0, behavior: 'smooth' }); } catch {}
+    try {
+      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+    } catch {
+      window.scrollTo(0, 0);
     }
   }, [location.pathname, location.search]);
 
@@ -67,8 +66,16 @@ const MainContent: React.FC<MainContentProps> = ({ children, title, sidebarColla
 
   return (
     <PageHeaderContext.Provider value={headerContextValue}>
-      <main className={`flex-1 flex flex-col overflow-hidden bg-gray-50 transition-all duration-300 ease-in-out ${sidebarCollapsed ? 'lg:p-4' : 'lg:p-4'}`}>
-        <header className="p-4">
+      <main className="bg-gray-50 min-h-[100dvh]">
+        {/*
+          Sticky header: z-10 creates a stacking context that sits above
+          page content (which is at z-auto) but below the sidebar drawer
+          (z-50) and modal Portals (z-50/z-[9999]). Header-anchored
+          dropdowns (OrgSwitcher z-20, NotificationDropdown z-50,
+          UserAccountButton z-20) stack within this header context, so
+          they paint above page content as expected.
+        */}
+        <header className="sticky top-0 z-10 bg-gray-50 p-4 border-b border-gray-200">
           <div className={containerClasses}>
             {/* Row 1: organization left, actions right (single row across sizes) */}
             <div className="flex items-center justify-between gap-2">
@@ -117,7 +124,7 @@ const MainContent: React.FC<MainContentProps> = ({ children, title, sidebarColla
           </div>
           </div>
         </header>
-        <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4">
+        <div className="p-4">
           <div className={containerClasses}>
             {children}
           </div>

--- a/apps/hindsight-dashboard/src/components/MemoryBlockDetailModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockDetailModal.tsx
@@ -136,7 +136,7 @@ const MemoryBlockDetailModal: React.FC<MemoryBlockDetailModalProps> = ({ blockId
 
   return createPortal(
     <div 
-      className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto h-full w-full z-[9999] flex items-start justify-center p-4"
+      className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto overscroll-contain h-full w-full z-[9999] flex items-start justify-center p-4"
       onClick={handleBackdropClick}
     >
       <div className="relative mt-8 mx-auto p-5 border border-gray-200 w-11/12 max-w-4xl shadow-xl rounded-lg bg-white animate-in fade-in-0 zoom-in-95 duration-200"

--- a/apps/hindsight-dashboard/src/components/MemoryBlockDetailModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockDetailModal.tsx
@@ -157,7 +157,7 @@ const MemoryBlockDetailModal: React.FC<MemoryBlockDetailModalProps> = ({ blockId
           </div>
 
           {/* Content */}
-          <div className="max-h-[70vh] overflow-y-auto"
+          <div className="max-h-[70vh] overflow-y-auto overscroll-contain"
                style={{ maxHeight: 'calc(90vh - 200px)' }}
           >
             {loading ? (
@@ -231,7 +231,7 @@ const MemoryBlockDetailModal: React.FC<MemoryBlockDetailModalProps> = ({ blockId
                       
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">Keywords</label>
-                        <div className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2">
+                        <div className="space-y-2 max-h-32 overflow-y-auto overscroll-contain border border-gray-200 rounded-md p-2">
                           {availableKeywords.map(keyword => (
                             <label key={keyword.id} className="flex items-center">
                               <input

--- a/apps/hindsight-dashboard/src/components/MemoryBlockPreviewModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockPreviewModal.tsx
@@ -167,7 +167,7 @@ const MemoryBlockPreviewModal: React.FC<MemoryBlockPreviewModalProps> = ({ isOpe
         </div>
 
         {/* Content - Scrollable */}
-        <div className="p-6 overflow-y-auto flex-1 min-h-0">
+        <div className="p-6 overflow-y-auto overscroll-contain flex-1 min-h-0">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-center">

--- a/apps/hindsight-dashboard/src/components/MemoryCompactionModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryCompactionModal.tsx
@@ -138,7 +138,7 @@ const MemoryCompactionModal: React.FC<MemoryCompactionModalProps> = ({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto overscroll-contain p-6">
           {!compactionResult ? (
             /* Initial State - Show original content and compaction options */
             <div className="space-y-6">

--- a/apps/hindsight-dashboard/src/components/MemoryCompactionModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryCompactionModal.tsx
@@ -145,7 +145,7 @@ const MemoryCompactionModal: React.FC<MemoryCompactionModalProps> = ({
               {/* Original Content */}
               <div>
                 <h3 className="text-lg font-medium text-gray-800 mb-3">Current Memory Content</h3>
-                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 max-h-64 overflow-y-auto">
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 max-h-64 overflow-y-auto overscroll-contain">
                   <div className="space-y-4">
                     {memoryBlock.content && (
                       <div>
@@ -255,7 +255,7 @@ const MemoryCompactionModal: React.FC<MemoryCompactionModalProps> = ({
                     <span className="w-3 h-3 bg-orange-500 rounded-full mr-2"></span>
                     Current Version
                   </h3>
-                  <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 max-h-96 overflow-y-auto">
+                  <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 max-h-96 overflow-y-auto overscroll-contain">
                     <div className="space-y-4">
                       {compactionResult.original_content && (
                         <div>
@@ -283,7 +283,7 @@ const MemoryCompactionModal: React.FC<MemoryCompactionModalProps> = ({
                     <span className="w-3 h-3 bg-green-500 rounded-full mr-2"></span>
                     Compacted Version
                   </h3>
-                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 max-h-96 overflow-y-auto">
+                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 max-h-96 overflow-y-auto overscroll-contain">
                     <div className="space-y-4">
                       {compactionResult.compressed_content && (
                         <div>

--- a/apps/hindsight-dashboard/src/components/MemoryCompressionModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryCompressionModal.tsx
@@ -122,7 +122,7 @@ const MemoryCompressionModal: React.FC<MemoryCompressionModalProps> = ({
               {/* Original Content */}
               <div>
                 <h3 className="text-lg font-medium text-gray-800 mb-3">Current Memory Content</h3>
-                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 max-h-64 overflow-y-auto">
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 max-h-64 overflow-y-auto overscroll-contain">
                   <div className="space-y-4">
                     {memoryBlock.content && (
                       <div>
@@ -228,7 +228,7 @@ const MemoryCompressionModal: React.FC<MemoryCompressionModalProps> = ({
                     <span className="w-3 h-3 bg-orange-500 rounded-full mr-2"></span>
                     Current Version
                   </h3>
-                  <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 max-h-96 overflow-y-auto">
+                  <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 max-h-96 overflow-y-auto overscroll-contain">
                     <div className="space-y-4">
                       {compactionResult.original_content && (
                         <div>
@@ -256,7 +256,7 @@ const MemoryCompressionModal: React.FC<MemoryCompressionModalProps> = ({
                     <span className="w-3 h-3 bg-green-500 rounded-full mr-2"></span>
                     Compacted Version
                   </h3>
-                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 max-h-96 overflow-y-auto">
+                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 max-h-96 overflow-y-auto overscroll-contain">
                     <div className="space-y-4">
                       {compactionResult.compressed_content && (
                         <div>

--- a/apps/hindsight-dashboard/src/components/MemoryCompressionModal.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryCompressionModal.tsx
@@ -115,7 +115,7 @@ const MemoryCompressionModal: React.FC<MemoryCompressionModalProps> = ({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto overscroll-contain p-6">
           {!compactionResult ? (
             /* Initial State - Show original content and compaction options */
             <div className="space-y-6">

--- a/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
@@ -560,7 +560,7 @@ const MemoryOptimizationCenter: FC = () => {
 
     return (
       <Portal>
-      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto h-full w-full z-50">
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm overflow-y-auto overscroll-contain h-full w-full z-50">
         <div className="relative top-20 mx-auto p-5 border w-11/12 max-w-4xl shadow-lg rounded-md bg-white">
           <div className="mt-3">
             {/* Header */}

--- a/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
@@ -597,7 +597,7 @@ const MemoryOptimizationCenter: FC = () => {
               <h4 className="text-lg font-medium text-gray-900 mb-3">
                 Affected Memory Blocks ({suggestion.affected_blocks?.length || 0})
               </h4>
-              <div className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg">
+              <div className="max-h-64 overflow-y-auto overscroll-contain border border-gray-200 rounded-lg">
                 {(suggestion.affected_blocks || []).length === 0 ? (
                   <div className="p-4 text-center text-gray-500">
                     No memory blocks specified for this suggestion.

--- a/apps/hindsight-dashboard/src/components/NotificationDropdown.tsx
+++ b/apps/hindsight-dashboard/src/components/NotificationDropdown.tsx
@@ -176,7 +176,7 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onClose, on
         </div>
 
         {/* Notification List */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto overscroll-contain">
           {loading && notifications.length === 0 ? (
             <div className="p-4 text-center">
               <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mx-auto"></div>

--- a/apps/hindsight-dashboard/src/components/NotificationSettingsModal.tsx
+++ b/apps/hindsight-dashboard/src/components/NotificationSettingsModal.tsx
@@ -125,7 +125,7 @@ const NotificationSettingsModal: React.FC<NotificationSettingsModalProps> = ({ i
         </div>
 
         {/* Content */}
-        <div className="px-6 py-4 overflow-y-auto max-h-[calc(90vh-140px)]">
+        <div className="px-6 py-4 overflow-y-auto overscroll-contain max-h-[calc(90vh-140px)]">
           {/* Guest User Message */}
           {guest && (
             <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">

--- a/apps/hindsight-dashboard/src/components/OrganizationManagement.tsx
+++ b/apps/hindsight-dashboard/src/components/OrganizationManagement.tsx
@@ -311,7 +311,7 @@ const OrganizationManagement: React.FC<OrganizationManagementProps> = ({ onClose
     return (
       <Portal>
         <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+          <div className="bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto overscroll-contain">
             <div className="flex items-center justify-center py-8">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
               <span className="ml-2">Loading organizations...</span>
@@ -326,7 +326,7 @@ const OrganizationManagement: React.FC<OrganizationManagementProps> = ({ onClose
     return (
       <Portal>
         <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+          <div className="bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto overscroll-contain">
             <div className="flex justify-between items-center mb-6">
               <h2 className="text-2xl font-bold text-gray-800">Access Denied</h2>
               <button
@@ -348,7 +348,7 @@ const OrganizationManagement: React.FC<OrganizationManagementProps> = ({ onClose
   return (
     <Portal>
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-6xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <div className="bg-white rounded-lg p-6 max-w-6xl w-full mx-4 max-h-[90vh] overflow-y-auto overscroll-contain">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-bold text-gray-800">Organization Management</h2>
           <button

--- a/apps/hindsight-dashboard/src/components/OrganizationManagement.tsx
+++ b/apps/hindsight-dashboard/src/components/OrganizationManagement.tsx
@@ -880,7 +880,7 @@ const AuditLogs: React.FC<{invitationId: string; orgId: string}> = ({ invitation
   if (!logs.length) return <div className="text-sm text-gray-600">No audit events for this invitation.</div>;
 
   return (
-    <div className="max-h-80 overflow-y-auto">
+    <div className="max-h-80 overflow-y-auto overscroll-contain">
       <table className="w-full border-collapse border border-gray-200 text-sm">
         <thead className="bg-gray-50">
           <tr>

--- a/apps/hindsight-dashboard/src/components/OrganizationSwitcher.tsx
+++ b/apps/hindsight-dashboard/src/components/OrganizationSwitcher.tsx
@@ -58,7 +58,7 @@ const OrganizationSwitcher: React.FC = () => {
             className="fixed inset-0 z-10"
             onClick={() => setIsOpen(false)}
           ></div>
-          <div className="absolute top-full left-0 right-0 md:right-auto mt-1 w-full md:w-[320px] bg-white border border-gray-200 rounded-lg shadow-lg z-20 max-h-80 overflow-y-auto">
+          <div className="absolute top-full left-0 right-0 md:right-auto mt-1 w-full md:w-[320px] bg-white border border-gray-200 rounded-lg shadow-lg z-20 max-h-80 overflow-y-auto overscroll-contain">
             {error && (
               <div className="px-3 py-2 text-sm text-red-600 bg-red-50 border-b border-gray-200">
                 {error}

--- a/apps/hindsight-dashboard/src/components/Sidebar.tsx
+++ b/apps/hindsight-dashboard/src/components/Sidebar.tsx
@@ -68,7 +68,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, onCollapseChange, on
   return (
     <>
       {isOpen && <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 lg:hidden" onClick={onClose} />}
-      <aside className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-64'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}>
+      <aside className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-64'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto overscroll-contain transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}>
         <div className="h-16 flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-700">
           <div className={`flex flex-col transition-all duration-200 ${isCollapsed ? 'opacity-0 w-0 overflow-hidden' : 'opacity-100 w-auto'}`}>
             <h1 className="text-lg font-bold text-white leading-tight">Hindsight AI</h1>

--- a/apps/hindsight-dashboard/src/index.css
+++ b/apps/hindsight-dashboard/src/index.css
@@ -1,8 +1,13 @@
 @import "tailwindcss";
 
 @layer base {
+  /*
+    Document is the scroller (RFC 0002 M1). Don't pin html/body to 100%
+    height or set overflow:hidden — that would clip the page to the
+    viewport and re-break iOS status-bar tap-to-top, scroll restoration,
+    and mouse-wheel-over-header.
+  */
   html, body, #root {
-    height: 100%;
     width: 100%;
   }
 
@@ -14,7 +19,6 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     background-color: #f3f4f6; /* bg-gray-100 */
-    overflow: hidden; /* Page height equals viewport; internal panes handle scroll on ≥sm */
   }
 
   * { box-sizing: border-box; }
@@ -184,9 +188,6 @@
 
 /* Responsive adjustments */
 @media (max-width: 640px) {
-  /* Allow natural document scrolling on small screens to avoid nested scroll issues */
-  html, body { overflow: auto; }
-
   .notification-container {
     bottom: calc(10px + env(safe-area-inset-bottom));
     right: calc(10px + env(safe-area-inset-right));


### PR DESCRIPTION
## Summary

Promotes scrolling to the document scroller. Pre-this-PR \`<main>\` and the
layout container both had \`overflow-hidden\` while a child div carried
\`overflow-y-auto\` — breaking iOS/Android tap-status-bar-to-scroll-top,
browser scroll restoration, mouse-wheel over header/sidebar, and
pull-to-refresh.

## Changes

### Layout / scroll
- \`Layout.tsx\`: drop outer \`flex overflow-hidden\` wrap + inner
  \`flex-col overflow-hidden\` column. Sidebar stays fixed.
- \`MainContent.tsx\`: drop \`overflow-hidden\` on \`<main>\`, drop the inner
  \`overflow-y-auto\` scroller div, set \`<main min-h-[100dvh]>\`, make the
  header \`sticky top-0 z-10 bg-gray-50 border-b border-gray-200\`.
  Drop the \`scrollRef\` branch in the route-change useEffect (would no-op now).
- \`sidebarCollapsed\` prop on MainContent is no longer used; dropped from
  interface and Layout invocation.

### Z-index ladder (documented inline in MainContent.tsx)
| Layer | z-index | Notes |
|---|---|---|
| Page content | z-auto | |
| Sticky header | z-10 | New stacking context |
| OrgSwitcher dropdown | z-20 | inside header context |
| UserAccountButton dropdown | z-20 | inside header context |
| NotificationDropdown | z-50 | inside header context |
| Sidebar drawer + backdrop | z-50 / z-40 | |
| Modal Portals | z-50 / z-[9999] | |

### \`overscroll-contain\` sweep
Per RFC: \"Add overscroll-contain to each inner scroller in the same PR.\"
- \`OrganizationSwitcher.tsx:61\` *(RFC-named)*
- \`NotificationDropdown.tsx:179\`
- \`MemoryBlockDetailModal.tsx:160, :234\` *(:160 RFC-named)*
- \`OrganizationManagement.tsx:883\` *(RFC-named)*
- \`MemoryCompressionModal.tsx:125, :231, :259\` (nested max-h sub-panels)
- \`MemoryCompactionModal.tsx:148, :258, :286\` (same)
- \`MemoryOptimizationCenter.tsx:600\`

Top-level modal scrollers (AboutModal, KeywordManager, GetStartedModal,
ConsolidationSuggestionModal, etc.) are intentionally **not** touched —
their parent Portal at z-[9999] already isolates wheel events from the
document.

## Test plan

- [x] \`npm run typecheck\` — 206 errors, **identical to baseline**, zero new
- [x] \`npm test\` — 268/268 pass
- [x] \`npm run build\` — clean
- [x] Re-ran audit script against M1 build — 1 finding (\`/memory-optimization-center\`
      horizontal overflow at mobile, 428 > 375). **Pre-existing M3-territory
      bug** previously masked by the now-removed overflow-hidden. Per RFC
      this is expected (\"M3 — Tokens table overflow … Lands after M1\").
- [x] User-menu interaction probe: dropdown z-stacks correctly above
      page content despite sticky header
- [ ] Manual smoke test: open OrgSwitcher, NotificationBell, UserAccount
      menus at desktop and mobile after rebuild — confirm none are clipped
- [ ] Manual: scroll a long page, confirm tap-status-bar-to-top works on
      mobile, browser back/forward restores scroll position

## Refs
RFC 0002 M1.