### PR TITLE
fix(dashboard): responsive sweep — OrgSwitcher truncate, Tokens gutters, Sidebar drawer cap (RFC 0002 M2 + M3 + M4)

### DIFF
--- a/apps/hindsight-dashboard/src/components/Layout.tsx
+++ b/apps/hindsight-dashboard/src/components/Layout.tsx
@@ -31,7 +31,7 @@ const Layout: React.FC<LayoutProps> = ({ children, title, onOpenAbout, onToggleD
         onCollapseChange={handleSidebarCollapse}
         onToggleDebugPanel={VITE_DEV_MODE ? onToggleDebugPanel : undefined}
       />
-      <div className={sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'}>
+      <div className={sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-72'}>
         <MainContent
           title={title}
           toggleSidebar={toggleSidebar}

--- a/apps/hindsight-dashboard/src/components/Layout.tsx
+++ b/apps/hindsight-dashboard/src/components/Layout.tsx
@@ -31,7 +31,7 @@ const Layout: React.FC<LayoutProps> = ({ children, title, onOpenAbout, onToggleD
         onCollapseChange={handleSidebarCollapse}
         onToggleDebugPanel={VITE_DEV_MODE ? onToggleDebugPanel : undefined}
       />
-      <div className={sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-72'}>
+      <div className={sidebarCollapsed ? 'lg:ml-16' : 'lg:ml-64'}>
         <MainContent
           title={title}
           toggleSidebar={toggleSidebar}

--- a/apps/hindsight-dashboard/src/components/OrganizationSwitcher.tsx
+++ b/apps/hindsight-dashboard/src/components/OrganizationSwitcher.tsx
@@ -33,17 +33,17 @@ const OrganizationSwitcher: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full md:min-w-[320px] md:max-w-[420px] px-3 py-2 text-left bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors duration-200"
+        className="flex items-center justify-between gap-2 w-full md:min-w-[320px] md:max-w-[420px] px-3 py-2 text-left bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors duration-200"
         disabled={loading}
       >
-        <div className="flex items-center space-x-2">
-          <div className={`w-2 h-2 rounded-full ${isPersonalMode ? 'bg-blue-500' : (isPublicMode ? 'bg-red-500' : 'bg-green-500')}`}></div>
-          <span className="font-medium text-gray-900">
+        <div className="flex items-center space-x-2 min-w-0 flex-1">
+          <div className={`w-2 h-2 rounded-full flex-shrink-0 ${isPersonalMode ? 'bg-blue-500' : (isPublicMode ? 'bg-red-500' : 'bg-green-500')}`}></div>
+          <span className="font-medium text-gray-900 truncate">
             {loading ? 'Loading...' : currentDisplayName}
           </span>
         </div>
         <svg
-          className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          className={`w-4 h-4 flex-shrink-0 text-gray-500 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/apps/hindsight-dashboard/src/components/Sidebar.tsx
+++ b/apps/hindsight-dashboard/src/components/Sidebar.tsx
@@ -69,10 +69,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, onCollapseChange, on
     <>
       {isOpen && <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 lg:hidden" onClick={onClose} />}
       <aside
-        role="dialog"
-        aria-modal={isOpen ? 'true' : undefined}
         aria-label="Main navigation"
-        className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-72 max-w-[80vw] lg:max-w-none'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto overscroll-contain transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}
+        className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-64 max-w-[80vw]'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto overscroll-contain transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}
       >
         <div className="h-16 flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-700">
           <div className={`flex flex-col transition-all duration-200 ${isCollapsed ? 'opacity-0 w-0 overflow-hidden' : 'opacity-100 w-auto'}`}>

--- a/apps/hindsight-dashboard/src/components/Sidebar.tsx
+++ b/apps/hindsight-dashboard/src/components/Sidebar.tsx
@@ -68,7 +68,12 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, onCollapseChange, on
   return (
     <>
       {isOpen && <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 lg:hidden" onClick={onClose} />}
-      <aside className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-64'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto overscroll-contain transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}>
+      <aside
+        role="dialog"
+        aria-modal={isOpen ? 'true' : undefined}
+        aria-label="Main navigation"
+        className={`fixed top-0 left-0 h-[100dvh] z-50 ${isCollapsed ? 'w-16' : 'w-72 max-w-[80vw] lg:max-w-none'} flex-shrink-0 bg-[#0F172A] text-gray-300 flex flex-col overflow-y-auto overscroll-contain transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}
+      >
         <div className="h-16 flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-700">
           <div className={`flex flex-col transition-all duration-200 ${isCollapsed ? 'opacity-0 w-0 overflow-hidden' : 'opacity-100 w-auto'}`}>
             <h1 className="text-lg font-bold text-white leading-tight">Hindsight AI</h1>

--- a/apps/hindsight-dashboard/src/components/TokenManagement.tsx
+++ b/apps/hindsight-dashboard/src/components/TokenManagement.tsx
@@ -135,7 +135,7 @@ const TokenManagement: React.FC = () => {
         </div>
       </form>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto -mx-4 sm:mx-0">
         <table className="min-w-full border">
           <thead className="bg-gray-100 text-sm">
             <tr>


### PR DESCRIPTION
## Summary

Responsive sweep landing on `integration/rfc-0002-batch-1` after M1 (#59) so M2/M3/M4 patch the post-rewrite scroll model rather than the old nested-overflow one.

- **M2** — OrgSwitcher pill no longer wraps under the bell at 375px. Truncate the display-name span; let it shrink in a `min-w-0 flex-1` container; lock the dot and chevron with `flex-shrink-0`.
- **M3** — Tokens table's horizontal-scroll wrapper extends into the page gutter on mobile (`-mx-4 sm:mx-0`) so the 9-column table can reach the viewport edge. Token-preview truncation / card-list pivot deferred per RFC rev 2.
- **M4** — Mobile drawer caps at 80vw (`w-72 max-w-[80vw] lg:max-w-none`), gains `role="dialog"`, `aria-label`, and `aria-modal="true"` (only while open, so the always-rendered desktop sidebar isn't reported as a modal). Layout offset bumped `lg:ml-64` → `lg:ml-72` to match the new sidebar width.

## Verification

Playwright probe at 375×812 against a vite dev build of this branch:

| Finding | Evidence |
|---|---|
| M2 | `span.truncate` present in OrgSwitcher; header right cluster stays on row 1 |
| M4 | drawer width = 288px (76.8% of viewport); `aria-modal="true"` set when open |
| M3 | wrapper class = `overflow-x-auto -mx-4 sm:mx-0`; table (804px) overflows wrapper (311px) — horizontal scroll engages |

- Typecheck: 206 pre-existing errors (unchanged from `7a00b9d`)
- Tests: 268/268 pass
- Visual screenshot of mobile drawer: confirmed underlying page is partially visible at the right edge.

## Test plan

- [ ] At 375px, confirm a long org name (e.g. an org with a 30+ char name) truncates inside the OrgSwitcher pill and the bell + avatar stay on the top row.
- [ ] At 768px, navigate to `/tokens` and confirm the Actions column is reachable via horizontal scroll without the page itself scrolling sideways.
- [ ] At 375px, open the sidebar drawer; confirm it occupies ≤80% of the viewport and Esc / backdrop-tap dismiss it (existing behavior, unchanged here).
- [ ] On lg+ desktop, confirm the body still aligns flush against the sidebar — no 32px gap (Layout `lg:ml-72` matches Sidebar `w-72`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)