### PR TITLE
fix(dashboard): wrap MemoryOptimizationCenter header on mobile (audit follow-up)

### DIFF
--- a/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryOptimizationCenter.tsx
@@ -727,8 +727,8 @@ const MemoryOptimizationCenter: FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
               <h1 className="text-3xl font-bold text-gray-900">Memory Optimization Center</h1>
               <p className="mt-2 text-gray-600">
                 AI-powered suggestions to improve your memory store
@@ -737,7 +737,7 @@ const MemoryOptimizationCenter: FC = () => {
                 <p className="mt-1 text-sm text-gray-500">LLM features are currently disabled. Compaction actions are unavailable.</p>
               )}
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4">
               <button
                 onClick={fetchSuggestions}
                 disabled={loading}


### PR DESCRIPTION
## Summary

Last audit finding before integration is clean. Audit at 375×812 reported:
\`\`\`
[medium] /memory-optimization-center (mobile) — Horizontal overflow: documentElement.scrollWidth=428 > viewport=375
\`\`\`

Root cause: the page-internal header at \`MemoryOptimizationCenter.tsx:730\` used \`flex items-center justify-between\` with the "Refresh Analysis" + "Back to Memory Blocks" button cluster pinned right and no wrap path. On a 375px viewport the cluster overflowed by ~53px.

Fix: stack the header column-then-row at \`sm:\`, and add \`flex-wrap\` on the button cluster so a third button (e.g. \`Debug Panel\` shown when \`VITE_DEV_MODE\`) also wraps gracefully.

3-line diff. Not part of RFC 0002's M3 (which targeted the Tokens table specifically), but blocks the "audit-clean" claim.

## Verification

Re-ran \`node .claude/skills/ui-ux-audit/audit.mjs\` against the integration tip with this patch applied:

\`\`\`
=== 0 findings written to /tmp/ui-audit/findings.json ===
\`\`\`

Down from 1 finding before this fix. All 3 viewports (mobile/tablet/desktop), all routes, all interaction probes — clean.

- Typecheck: 206 pre-existing errors (unchanged from \`caf604e\`)
- Tests: 268/268 pass

## Test plan

- [ ] At 375px on \`/memory-optimization-center\`, confirm "Refresh Analysis" and "Back to Memory Blocks" sit on the row below the title and within the viewport.
- [ ] At ≥640px, confirm the buttons return to the top-right cluster opposite the title.
- [ ] In dev mode (VITE_DEV_MODE=true), confirm a third "Debug Panel" button wraps below the first two on narrow viewports rather than overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)