### PR TITLE
fix(backend): close 2 correctness gaps from PR #87 audit (#88, #89)

### DIFF
--- a/apps/hindsight-service/core/api/beta_access.py
+++ b/apps/hindsight-service/core/api/beta_access.py
@@ -261,6 +261,11 @@ def update_beta_access_user_status(
     request = beta_repo.get_beta_access_request_by_email(db, user.email)
     reviewer_email = admin_user.email
 
+    # Single-transaction atomicity (#89): the request-side write + user-row
+    # mirror used to be two separate commits; if the process died between
+    # them the request was 'accepted' but the user row still read 'pending'
+    # until the user's next login normalized things. Now both writes share
+    # one db.commit() — autocommit=False on the repo call defers to us.
     if desired in {"accepted", "denied"} and request:
         beta_repo.update_beta_access_request_status(
             db,
@@ -268,8 +273,8 @@ def update_beta_access_user_status(
             desired,
             reviewer_email,
             "Manual status update via beta access admin console",
+            autocommit=False,
         )
-        request = beta_repo.get_beta_access_request_by_email(db, user.email)
     elif desired in {"revoked", "not_requested"} and request and request.status != 'denied':
         beta_repo.update_beta_access_request_status(
             db,
@@ -277,11 +282,10 @@ def update_beta_access_user_status(
             'denied',
             reviewer_email,
             "Access manually revoked via beta access admin console",
+            autocommit=False,
         )
-        request = beta_repo.get_beta_access_request_by_email(db, user.email)
 
-    # Mirror the result to the user row only after the request-side write
-    # succeeded.
+    # Mirror the result to the user row in the same transaction.
     user.beta_access_status = desired
 
     try:
@@ -290,6 +294,8 @@ def update_beta_access_user_status(
         db.rollback()
         raise HTTPException(status_code=500, detail="Failed to persist beta access status update.") from exc
     db.refresh(user)
+    # Refresh the request snapshot we'll return in the audit log.
+    request = beta_repo.get_beta_access_request_by_email(db, user.email)
 
     audit_callable = getattr(sys.modules[__name__], "audit_log", audit_log)
     audit_callable(

--- a/apps/hindsight-service/core/api/main.py
+++ b/apps/hindsight-service/core/api/main.py
@@ -3,6 +3,7 @@ FastAPI app assembly: middleware and router wiring.
 """
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -43,10 +44,32 @@ from core.api.memory_blocks_bulk import router as memory_blocks_bulk_router
 
 # Database schema is managed by Alembic migrations.
 
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Startup / shutdown hooks.
+
+    On startup: reconcile bulk operations stuck in `running` state across
+    a process restart (#88). The check runs synchronously before the app
+    accepts traffic; failure to reconcile is logged but does not block
+    startup (better to serve traffic than to crash on a transient DB
+    glitch).
+    """
+    try:
+        from core.async_bulk_operations import reconcile_stuck_bulk_operations
+        reconciled = reconcile_stuck_bulk_operations(min_age_seconds=60)
+        if reconciled:
+            logger.info("startup: reconciled %d stuck bulk operations to 'failed'", reconciled)
+    except Exception as exc:  # pragma: no cover — defensive logging
+        logger.warning("startup: bulk-operation reconciliation failed: %s", exc)
+    yield
+
+
 app = FastAPI(
     title="Intelligent AI Agent Memory Service",
     description="API for managing AI agent memories, including creation, retrieval, and feedback.",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 # Avoid implicit trailing-slash redirects for predictable URLs

--- a/apps/hindsight-service/core/async_bulk_operations.py
+++ b/apps/hindsight-service/core/async_bulk_operations.py
@@ -430,6 +430,67 @@ async def execute_bulk_operation_async(operation_id: uuid.UUID, task_type: str,
     )
 
 
+def reconcile_stuck_bulk_operations(
+    min_age_seconds: int = 60,
+    session: Optional[Any] = None,
+) -> int:
+    """Mark abandoned `running` bulk operations as failed.
+
+    Closes the rolling-deploy gap from #88: when the API process is killed
+    (e.g. `docker stop`) while a bulk operation is mid-flight, the
+    in-memory task dict dies with the process but the DB row stays at
+    `status='running'` indefinitely. The status endpoint then reports the
+    operation as live forever.
+
+    Called from the FastAPI `lifespan` startup hook in `core/api/main.py`
+    BEFORE the new process accepts traffic. Reconciles any rows whose
+    `started_at` is older than `min_age_seconds` (default 60s) — that
+    grace window prevents a graceful-restart blue/green deploy from
+    falsely failing in-flight operations whose worker is still alive.
+
+    `session` is an optional injected SQLAlchemy session — used by tests
+    that seed rows in a SAVEPOINT-wrapped transaction (where a separate
+    `SessionLocal()` connection cannot see the uncommitted seeds). When
+    omitted, the function opens and closes its own session as in production.
+
+    Returns the number of rows reconciled.
+    """
+    from datetime import datetime, timedelta, timezone
+    from core.db import models
+    owns_session = session is None
+    if owns_session:
+        from core.db.database import SessionLocal
+        db = SessionLocal()
+    else:
+        db = session
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=min_age_seconds)
+        stuck = (
+            db.query(models.BulkOperation)
+            .filter(
+                models.BulkOperation.status == 'running',
+                models.BulkOperation.started_at != None,  # noqa: E711 — SQLAlchemy needs `!=` not `is not`
+                models.BulkOperation.started_at < cutoff,
+            )
+            .all()
+        )
+        for op in stuck:
+            op.status = 'failed'
+            op.finished_at = datetime.now(timezone.utc)
+            existing_log = op.error_log or {}
+            errors = list(existing_log.get('errors') or [])
+            errors.append('server restarted before operation could complete')
+            op.error_log = {**existing_log, 'errors': errors}
+        if stuck and owns_session:
+            db.commit()
+        elif stuck:
+            db.flush()
+        return len(stuck)
+    finally:
+        if owns_session:
+            db.close()
+
+
 def get_bulk_operation_status(operation_id: uuid.UUID) -> Optional[Dict[str, Any]]:
     """Get the status of a bulk operation."""
     return _bulk_operations_manager.get_task_status(operation_id)

--- a/apps/hindsight-service/core/db/repositories/beta_access.py
+++ b/apps/hindsight-service/core/db/repositories/beta_access.py
@@ -83,8 +83,19 @@ def update_beta_access_request_status(
     request_id: uuid.UUID,
     status: str,
     reviewer_email: Optional[str] = None,
-    decision_reason: Optional[str] = None
+    decision_reason: Optional[str] = None,
+    autocommit: bool = True,
 ) -> Optional[models.BetaAccessRequest]:
+    """Update a beta-access request row.
+
+    When `autocommit=True` (default) the change is committed immediately —
+    backward-compatible behavior preserved for the many existing callers.
+
+    Pass `autocommit=False` when the caller needs to commit several writes
+    atomically in one transaction (e.g. the admin-override flow that also
+    mirrors the result to `User.beta_access_status`). The caller becomes
+    responsible for invoking `db.commit()` and any `db.refresh(...)`.
+    """
     db_request = db.query(models.BetaAccessRequest).filter(models.BetaAccessRequest.id == request_id).first()
     if db_request:
         db_request.status = status
@@ -93,8 +104,11 @@ def update_beta_access_request_status(
         db_request.decision_reason = decision_reason
         db_request.review_token = None
         db_request.token_expires_at = None
-        db.commit()
-        db.refresh(db_request)
+        if autocommit:
+            db.commit()
+            db.refresh(db_request)
+        else:
+            db.flush()
     return db_request
 
 

--- a/apps/hindsight-service/tests/integration/beta_access/test_atomicity.py
+++ b/apps/hindsight-service/tests/integration/beta_access/test_atomicity.py
@@ -1,0 +1,119 @@
+"""Regression test for #89 — beta-access admin override atomicity.
+
+Pre-#89, `update_beta_access_request_status` committed internally and the
+caller in `core/api/beta_access.py` then committed `user.beta_access_status`
+in a second transaction. A process death between the two commits left the
+request record updated but the user row stale until next login.
+
+Post-#89, the repo function accepts `autocommit=False` to defer commit to
+the caller. The admin-override flow uses this so both writes share one
+transaction — atomic semantics.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from core.db import models
+from core.db.repositories import beta_access as beta_repo
+
+
+def _seed_user_and_request(db: Session, status: str = "pending") -> tuple[models.User, models.BetaAccessRequest]:
+    user = models.User(
+        email=f"atomic-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Atomic Test User",
+        beta_access_status=status,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    req = models.BetaAccessRequest(
+        user_id=user.id,
+        email=user.email,
+        status=status,
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return user, req
+
+
+def test_autocommit_true_preserves_legacy_behavior(db_session: Session):
+    """Default behavior unchanged: the repo commits and the change is visible immediately."""
+    _, req = _seed_user_and_request(db_session)
+    updated = beta_repo.update_beta_access_request_status(
+        db_session,
+        req.id,
+        "accepted",
+        reviewer_email="admin@example.com",
+        decision_reason="auto-approved",
+    )
+    assert updated is not None
+    assert updated.status == "accepted"
+    # Visible to a fresh query (committed)
+    assert db_session.query(models.BetaAccessRequest).get(req.id).status == "accepted"
+
+
+def test_autocommit_false_defers_commit_to_caller(db_session: Session):
+    """With autocommit=False, the change lives in the session but not the DB until caller commits."""
+    user, req = _seed_user_and_request(db_session)
+
+    beta_repo.update_beta_access_request_status(
+        db_session,
+        req.id,
+        "accepted",
+        reviewer_email="admin@example.com",
+        decision_reason="manual",
+        autocommit=False,
+    )
+    # The session sees the change — but the row is still in the open txn,
+    # not committed. Mirror to user row in the same txn.
+    user.beta_access_status = "accepted"
+
+    # Until commit, both writes can be rolled back together.
+    db_session.commit()
+
+    fresh_req = db_session.query(models.BetaAccessRequest).get(req.id)
+    fresh_user = db_session.query(models.User).get(user.id)
+    assert fresh_req.status == "accepted"
+    assert fresh_user.beta_access_status == "accepted"
+
+
+def test_autocommit_false_rollback_unwinds_both_writes(db_session: Session):
+    """If something fails before commit, both the request-side AND user-side writes roll back atomically."""
+    user, req = _seed_user_and_request(db_session, status="pending")
+
+    beta_repo.update_beta_access_request_status(
+        db_session,
+        req.id,
+        "accepted",
+        reviewer_email="admin@example.com",
+        decision_reason="manual",
+        autocommit=False,
+    )
+    user.beta_access_status = "accepted"
+
+    # Simulate something going wrong before the caller commits.
+    db_session.rollback()
+
+    fresh_req = db_session.query(models.BetaAccessRequest).get(req.id)
+    fresh_user = db_session.query(models.User).get(user.id)
+    # Pre-#89 the request would already be committed and the user row would
+    # not — leaving the half-applied state. Post-#89, both stay at 'pending'.
+    assert fresh_req.status == "pending"
+    assert fresh_user.beta_access_status == "pending"
+
+
+def test_autocommit_false_returns_none_when_request_missing(db_session: Session):
+    """No-op signal preserved: missing row returns None without raising."""
+    result = beta_repo.update_beta_access_request_status(
+        db_session,
+        uuid.uuid4(),  # nonexistent
+        "accepted",
+        autocommit=False,
+    )
+    assert result is None

--- a/apps/hindsight-service/tests/integration/bulk_operations/test_startup_reconciliation.py
+++ b/apps/hindsight-service/tests/integration/bulk_operations/test_startup_reconciliation.py
@@ -1,0 +1,140 @@
+"""Regression test for #88 — bulk-op startup reconciliation.
+
+Pre-#88, killing the API process mid-bulk-operation left the DB row at
+status='running' indefinitely. The status endpoint reported the long-dead
+operation as live forever.
+
+Post-#88, `reconcile_stuck_bulk_operations()` runs from the FastAPI
+`lifespan` startup hook BEFORE the new process accepts traffic. It marks
+any `running` row whose `started_at` is older than a grace window
+(default 60s) as `failed` with an annotated `error_log`.
+
+The grace window prevents a graceful blue/green deploy from falsely
+failing operations whose worker is still alive in the new process.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from core.async_bulk_operations import reconcile_stuck_bulk_operations
+from core.db import models
+
+
+def _seed_user_and_org(db: Session) -> tuple[models.User, models.Organization]:
+    user = models.User(
+        email=f"reconcile-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Reconcile Test User",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    org = models.Organization(name=f"reconcile-org-{uuid.uuid4().hex[:6]}", slug=f"reconcile-{uuid.uuid4().hex[:6]}")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return user, org
+
+
+def test_reconcile_marks_old_running_rows_as_failed(db_session: Session):
+    """A `running` op whose started_at is well past the grace window flips to failed."""
+    user, org = _seed_user_and_org(db_session)
+    op = models.BulkOperation(
+        type="bulk_compact",
+        actor_user_id=user.id,
+        organization_id=org.id,
+        status="running",
+        started_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    db_session.add(op)
+    db_session.commit()
+    db_session.refresh(op)
+
+    reconciled = reconcile_stuck_bulk_operations(min_age_seconds=60, session=db_session)
+    assert reconciled >= 1
+
+    db_session.expire_all()
+    fresh = db_session.query(models.BulkOperation).get(op.id)
+    assert fresh.status == "failed"
+    assert fresh.finished_at is not None
+    assert "server restarted" in (fresh.error_log or {}).get("errors", [""])[0]
+
+
+def test_reconcile_skips_recent_running_rows_within_grace(db_session: Session):
+    """A `running` op whose started_at is INSIDE the grace window is left alone — graceful-restart safety."""
+    user, org = _seed_user_and_org(db_session)
+    op = models.BulkOperation(
+        type="bulk_compact",
+        actor_user_id=user.id,
+        organization_id=org.id,
+        status="running",
+        started_at=datetime.now(timezone.utc) - timedelta(seconds=10),  # within 60s grace
+    )
+    db_session.add(op)
+    db_session.commit()
+    db_session.refresh(op)
+
+    # Pass a 60s grace window; this op is only 10s old — should NOT be reconciled
+    reconcile_stuck_bulk_operations(min_age_seconds=60, session=db_session)
+
+    db_session.expire_all()
+    fresh = db_session.query(models.BulkOperation).get(op.id)
+    assert fresh.status == "running"
+    assert fresh.finished_at is None
+
+
+def test_reconcile_skips_terminal_status_rows(db_session: Session):
+    """`completed` / `failed` / `cancelled` rows are left untouched (idempotent)."""
+    user, org = _seed_user_and_org(db_session)
+    long_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+    finished_op = models.BulkOperation(
+        type="bulk_compact",
+        actor_user_id=user.id,
+        organization_id=org.id,
+        status="completed",
+        started_at=long_ago,
+        finished_at=long_ago,
+    )
+    db_session.add(finished_op)
+    db_session.commit()
+    db_session.refresh(finished_op)
+
+    reconcile_stuck_bulk_operations(min_age_seconds=60, session=db_session)
+
+    db_session.expire_all()
+    fresh = db_session.query(models.BulkOperation).get(finished_op.id)
+    assert fresh.status == "completed"
+
+
+def test_reconcile_appends_error_to_existing_log(db_session: Session):
+    """If error_log already has entries, we append rather than clobber."""
+    user, org = _seed_user_and_org(db_session)
+    op = models.BulkOperation(
+        type="bulk_compact",
+        actor_user_id=user.id,
+        organization_id=org.id,
+        status="running",
+        started_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        error_log={"errors": ["worker reported partial failure"]},
+    )
+    db_session.add(op)
+    db_session.commit()
+    db_session.refresh(op)
+
+    reconcile_stuck_bulk_operations(min_age_seconds=60, session=db_session)
+
+    db_session.expire_all()
+    fresh = db_session.query(models.BulkOperation).get(op.id)
+    errors = (fresh.error_log or {}).get("errors", [])
+    assert len(errors) == 2
+    assert errors[0] == "worker reported partial failure"
+    assert "server restarted" in errors[1]
+
+
+def test_reconcile_returns_zero_when_nothing_stuck(db_session: Session):
+    """Empty case is a no-op."""
+    reconciled = reconcile_stuck_bulk_operations(min_age_seconds=60)
+    assert reconciled == 0


### PR DESCRIPTION
## Summary

Two state-machine fixes surfaced by the failure-mode audit on the architecture-smell backlog merge (PR #87).

- **#88** — reconcile stuck-\`running\` bulk operations on FastAPI startup; closes the rolling-deploy gap (process killed mid-operation → DB row stays \`running\` forever)
- **#89** — beta-access admin override is now a single transaction; pre-fix could leave request-row 'accepted' while user-row still 'pending' if the process died between two separate commits

## Verification

- \`uv run pytest --cov=core --cov-fail-under=80\`:
  - **884 passed**, 8 skipped (was 875/8, +9 from new tests)
  - **Coverage 80.75%** (gate 80%) ✓

## Diff stats

```
6 files changed, 370 insertions(+), 7 deletions(-)
```

## Test plan

- [ ] CI green
- [ ] Manual: trigger a long bulk operation on staging, kill the API container, restart, verify the operation row flips to \`failed\` within 60s of restart with \`error_log.errors\` containing 'server restarted before operation could complete'
- [ ] Manual: as a beta-access admin, change a user from pending → accepted; confirm both BetaAccessRequest.status AND User.beta_access_status reflect the new state immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)