### PR TITLE
refactor(deps): split deps.py — extract context_types + dev_mode_setup (#92)

### DIFF
--- a/apps/hindsight-service/core/api/context_types.py
+++ b/apps/hindsight-service/core/api/context_types.py
@@ -1,0 +1,65 @@
+"""Typed per-request context dataclasses.
+
+Extracted from ``core.api.deps`` (#92) — that module had grown to 678 LOC
+mixing dataclass definitions, FastAPI ``Depends`` resolvers, dev-mode
+PAT provisioning, and PAT-scope narrowing. This module owns only the
+type definitions; resolvers stay in ``deps.py``.
+
+Re-exported by ``deps.py`` so the ~50 caller modules continue to do
+``from core.api.deps import UserContext, RequestContext`` without
+changes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type hints
+    from core.db import models
+    from core.db.scope_utils import ScopeContext
+
+
+@dataclass(frozen=True)
+class PatContext:
+    """Metadata about the PAT used to authenticate this request."""
+    id: Any
+    token_id: str
+    scopes: List[str]
+    organization_id: Optional[Any]
+
+
+@dataclass(frozen=True)
+class CurrentUserContext:
+    """Per-request user context.
+
+    Replaces the legacy Dict[str, Any] shape. Consumers should access via
+    attribute (``ctx.is_superadmin``) instead of dict get
+    (``ctx.get('is_superadmin')``). Mistyped attribute access fails
+    loudly at the call site instead of silently returning ``None`` — the
+    entire reason this type exists.
+    """
+    id: Any
+    email: str
+    display_name: Optional[str]
+    is_superadmin: bool
+    is_beta_access_admin: bool
+    memberships: List[Dict[str, Any]]
+    memberships_by_org: Dict[str, Dict[str, Any]]
+    beta_access_status: Optional[str]
+    pat: Optional[PatContext] = None
+    dev_mode_pat: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class UserContext:
+    """Result of ``get_current_user_context*()`` — pairs the ORM user row with the typed ``CurrentUserContext``."""
+    user: "models.User"
+    current: CurrentUserContext
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Result of ``get_scoped_user_and_context()`` — adds ``ScopeContext`` on top of ``UserContext``."""
+    user: "models.User"
+    current: CurrentUserContext
+    scope: "ScopeContext"

--- a/apps/hindsight-service/core/api/deps.py
+++ b/apps/hindsight-service/core/api/deps.py
@@ -2,11 +2,14 @@
 API dependency helpers.
 
 Provides dependency-resolved user context and scope information for routes.
+The typed dataclasses (PatContext, CurrentUserContext, UserContext,
+RequestContext) live in `core.api.context_types`; the dev-mode user
+provisioning lives in `core.api.dev_mode_setup`. This module owns only the
+FastAPI ``Depends``-decorated resolvers and the PAT-permission predicates.
 """
 import uuid
 import logging
 import dataclasses as _dc
-from dataclasses import dataclass, field
 from typing import Optional, Tuple, Dict, Any, List
 from uuid import UUID
 from fastapi import Query
@@ -16,35 +19,14 @@ import os
 from sqlalchemy import text as _sql_text
 from sqlalchemy.orm import Session
 
-
-@dataclass(frozen=True)
-class PatContext:
-    """Metadata about the PAT used to authenticate this request."""
-    id: Any
-    token_id: str
-    scopes: List[str]
-    organization_id: Optional[Any]
-
-
-@dataclass(frozen=True)
-class CurrentUserContext:
-    """Per-request user context.
-
-    Replaces the legacy Dict[str, Any] shape. Consumers should access via
-    attribute (`ctx.is_superadmin`) instead of dict get (`ctx.get('is_superadmin')`).
-    Mistyped attribute access fails loudly at the call site instead of
-    silently returning None — the entire reason this type exists.
-    """
-    id: Any
-    email: str
-    display_name: Optional[str]
-    is_superadmin: bool
-    is_beta_access_admin: bool
-    memberships: List[Dict[str, Any]]
-    memberships_by_org: Dict[str, Dict[str, Any]]
-    beta_access_status: Optional[str]
-    pat: Optional[PatContext] = None
-    dev_mode_pat: Optional[str] = None
+# Re-export the typed context dataclasses so the ~50 caller modules keep
+# importing them via `core.api.deps` unchanged.
+from core.api.context_types import (
+    PatContext,
+    CurrentUserContext,
+    UserContext,
+    RequestContext,
+)
 
 from core.db.database import get_db
 from core.api.auth import (
@@ -84,74 +66,10 @@ from core.db.scope_utils import ScopeContext
 from core.db.repositories import tokens as token_repo
 from core.utils.token_crypto import parse_token, verify_secret
 from core.utils.runtime import dev_mode_active
-from core.db.schemas.tokens import TokenCreateRequest
+from core.api.dev_mode_setup import ensure_dev_mode_defaults as _ensure_dev_mode_defaults
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class UserContext:
-    """Result of get_current_user_context*() — pairs the ORM user row with the typed CurrentUserContext."""
-    user: models.User
-    current: CurrentUserContext
-
-
-@dataclass(frozen=True)
-class RequestContext:
-    """Result of get_scoped_user_and_context() — adds ScopeContext on top of UserContext."""
-    user: models.User
-    current: CurrentUserContext
-    scope: ScopeContext
-
-_DEV_MODE_PAT_CACHE: Optional[str] = None
-
-
-def _ensure_dev_mode_defaults(db: Session, user: models.User) -> Optional[str]:
-    """Ensure dev@localhost has superadmin rights, beta access, and a PAT."""
-    global _DEV_MODE_PAT_CACHE
-
-    changed = False
-    if not getattr(user, "is_superadmin", False):
-        user.is_superadmin = True
-        changed = True
-    if getattr(user, "beta_access_status", "") != "accepted":
-        user.beta_access_status = "accepted"
-        changed = True
-
-    if changed:
-        try:
-            db.commit()
-        except Exception:
-            db.rollback()
-        else:
-            db.refresh(user)
-
-    # Reuse cached PAT token when still valid for this user
-    token_value: Optional[str] = None
-    if _DEV_MODE_PAT_CACHE:
-        parsed = parse_token(_DEV_MODE_PAT_CACHE)
-        if parsed:
-            pat = token_repo.get_by_token_id(db, token_id=parsed.token_id)
-            if pat and pat.status == "active" and pat.user_id == user.id:
-                token_value = _DEV_MODE_PAT_CACHE
-
-    if token_value is not None:
-        return token_value
-
-    active_tokens = [pat for pat in token_repo.list_tokens(db, user_id=user.id) if pat.status == "active"]
-    full_token: Optional[str] = None
-    if active_tokens:
-        rotated = token_repo.rotate_token(db, token_db_id=active_tokens[0].id, user_id=user.id)
-        if rotated:
-            _pat, full_token = rotated
-    if not full_token:
-        payload = TokenCreateRequest(name="Dev Mode Default PAT", scopes=["read", "write"])
-        _pat, full_token = token_repo.create_token(db, user_id=user.id, payload=payload)
-
-    _DEV_MODE_PAT_CACHE = full_token
-    logger.info("DEV_MODE PAT token issued for %s: %s", user.email, full_token)
-    return full_token
 
 # Contract:
 # Returns UserContext(user, current) — raises 401 if identity cannot be resolved.

--- a/apps/hindsight-service/core/api/dev_mode_setup.py
+++ b/apps/hindsight-service/core/api/dev_mode_setup.py
@@ -1,0 +1,78 @@
+"""Dev-mode user provisioning.
+
+Extracted from ``core.api.deps`` (#92). Provisions superadmin rights,
+beta-access acceptance, and a default PAT for ``dev@localhost`` users
+on every dev-mode request. Cached PAT token is reused across requests
+in the same process to avoid issuing a new token on every login.
+
+Imported and called by ``get_current_user_context()`` in ``deps.py``
+when ``dev_mode_active()`` is true. Does nothing in normal/production
+mode.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from core.db import models
+from core.db.repositories import tokens as token_repo
+from core.db.schemas.tokens import TokenCreateRequest
+from core.utils.token_crypto import parse_token
+
+logger = logging.getLogger(__name__)
+
+# Process-local cache so dev sessions don't issue a new PAT on every request.
+# Reset by a process restart or by token rotation in the DB.
+_DEV_MODE_PAT_CACHE: Optional[str] = None
+
+
+def ensure_dev_mode_defaults(db: Session, user: models.User) -> Optional[str]:
+    """Ensure dev@localhost has superadmin rights, beta access, and a PAT.
+
+    Returns the active dev-mode PAT (cached in-process or freshly minted).
+    """
+    global _DEV_MODE_PAT_CACHE
+
+    changed = False
+    if not getattr(user, "is_superadmin", False):
+        user.is_superadmin = True
+        changed = True
+    if getattr(user, "beta_access_status", "") != "accepted":
+        user.beta_access_status = "accepted"
+        changed = True
+
+    if changed:
+        try:
+            db.commit()
+        except Exception:
+            db.rollback()
+        else:
+            db.refresh(user)
+
+    # Reuse cached PAT token when still valid for this user
+    token_value: Optional[str] = None
+    if _DEV_MODE_PAT_CACHE:
+        parsed = parse_token(_DEV_MODE_PAT_CACHE)
+        if parsed:
+            pat = token_repo.get_by_token_id(db, token_id=parsed.token_id)
+            if pat and pat.status == "active" and pat.user_id == user.id:
+                token_value = _DEV_MODE_PAT_CACHE
+
+    if token_value is not None:
+        return token_value
+
+    active_tokens = [pat for pat in token_repo.list_tokens(db, user_id=user.id) if pat.status == "active"]
+    full_token: Optional[str] = None
+    if active_tokens:
+        rotated = token_repo.rotate_token(db, token_db_id=active_tokens[0].id, user_id=user.id)
+        if rotated:
+            _pat, full_token = rotated
+    if not full_token:
+        payload = TokenCreateRequest(name="Dev Mode Default PAT", scopes=["read", "write"])
+        _pat, full_token = token_repo.create_token(db, user_id=user.id, payload=payload)
+
+    _DEV_MODE_PAT_CACHE = full_token
+    logger.info("DEV_MODE PAT token issued for %s: %s", user.email, full_token)
+    return full_token


### PR DESCRIPTION
## Summary

Resolves smell-scanner MEDIUM finding from PR #87 audit. \`deps.py\` had grown to **678 LOC** absorbing responsibility from #69, #70, and #84 with the highest production-code consumer fan-in (~52 importers) of any non-model file in the service.

Two extractions, zero caller-side churn (re-exports preserve the import surface):

- \`core/api/context_types.py\` (NEW, 65 LOC) — 4 frozen dataclasses (\`PatContext\`, \`CurrentUserContext\`, \`UserContext\`, \`RequestContext\`)
- \`core/api/dev_mode_setup.py\` (NEW, 78 LOC) — dev-mode user provisioning (\`ensure_dev_mode_defaults\`)
- \`deps.py\` 678 → **596 LOC** (-82)

All 52 \`from core.api.deps import ...\` callers continue to work via re-exports. No migration needed.

## Verification

- \`uv run pytest --cov=core --cov-fail-under=80\`:
  - **875 passed**, 8 skipped (unchanged baseline)
  - **Coverage 80.79%** ✓

## Diff stats

```
3 files changed, 156 insertions(+), 95 deletions(-)
```

## Test plan

- [ ] CI green
- [ ] Manual: dev-mode login on localhost still provisions superadmin + PAT (verify the cached PAT path)
- [ ] Manual: spot-check 2-3 PAT-authenticated routes still work (PatContext flow unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)