### PR TITLE
feat(e2e): test-fixtures endpoint + journey 5 (consolidation) (#106)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ env:
   # `e2e-admin@e2e.local`: provisions other test users via PATCH /beta-access/admin/users/{id}
   # `e2e-reference-owner@e2e.local`: owns the search-journey reference dataset (50 blocks)
   BETA_ACCESS_ADMINS: e2e-admin@e2e.local,e2e-reference-owner@e2e.local
+  # Mount /test-fixtures/* endpoints (gated module). NEVER set this in production.
+  # See apps/hindsight-service/core/api/test_fixtures.py for the security model.
+  E2E_TEST_HOOKS: 'true'
 
 jobs:
   smoke:

--- a/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
@@ -22,7 +22,7 @@ test.describe('Journey 5 — Consolidation validate / reject @full', () => {
   test('seeded suggestions can be validated and rejected via the UI', async ({ page, request }) => {
     const email = temail('consolidation-user');
     await provisionUser(page, email);
-    const headers = { 'x-auth-request-email': email, 'x-auth-request-user': email };
+    const headers = { 'x-auth-request-email': email, 'x-auth-request-user': email, 'x-active-scope': 'personal' };
 
     // ── 1. Seed agent + 2 source memory blocks ───────────────────────────────
     const agentRes = await request.post(`${BACKEND}/agents/`, {

--- a/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { asUser } from '../helpers/auth';
+import { provisionUser } from '../helpers/provision';
+import { temail, tname, runId } from '../helpers/runId';
+
+/**
+ * Journey 5 — Consolidation validate / reject. (RFC v3, umbrella #96, issue #106)
+ *
+ * Uses the new test-only fixture endpoint
+ * `POST /test-fixtures/consolidation-suggestion` (gated behind
+ * `E2E_TEST_HOOKS=true` — see `core/api/test_fixtures.py`) to seed
+ * suggestion rows directly. The production-path generation goes through
+ * the LLM-driven consolidation worker which is gated by
+ * `LLM_FEATURES_ENABLED=true` and not available in CI.
+ *
+ * Tagged @full — runs on push to staging.
+ */
+
+const BACKEND = 'http://localhost:8000';
+
+test.describe('Journey 5 — Consolidation validate / reject @full', () => {
+  test('seeded suggestions can be validated and rejected via the UI', async ({ page, request }) => {
+    const email = temail('consolidation-user');
+    await provisionUser(page, email);
+    const headers = { 'x-auth-request-email': email, 'x-auth-request-user': email };
+
+    // ── 1. Seed agent + 2 source memory blocks ───────────────────────────────
+    const agentRes = await request.post(`${BACKEND}/agents/`, {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: { agent_name: tname('cons-agent'), visibility_scope: 'personal' },
+    });
+    expect(agentRes.ok()).toBe(true);
+    const agent = await agentRes.json();
+
+    const block1Res = await request.post(`${BACKEND}/memory-blocks/`, {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: {
+        agent_id: agent.agent_id,
+        conversation_id: '00000000-0000-0000-0000-000000000501',
+        content: `Original block 1 ${runId}`,
+        lessons_learned: 'Lesson 1',
+        visibility_scope: 'personal',
+      },
+    });
+    const block1 = await block1Res.json();
+
+    const block2Res = await request.post(`${BACKEND}/memory-blocks/`, {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: {
+        agent_id: agent.agent_id,
+        conversation_id: '00000000-0000-0000-0000-000000000502',
+        content: `Original block 2 ${runId}`,
+        lessons_learned: 'Lesson 2',
+        visibility_scope: 'personal',
+      },
+    });
+    const block2 = await block2Res.json();
+
+    // ── 2. Seed two consolidation suggestions via the test-fixture endpoint ──
+    const suggestion1ToValidate = `Validate-${runId}`;
+    const seed1Res = await request.post(`${BACKEND}/test-fixtures/consolidation-suggestion`, {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: {
+        suggested_content: `${suggestion1ToValidate}: merged content (will be validated)`,
+        suggested_lessons_learned: 'Validated suggestion lesson',
+        suggested_keywords: ['merged', 'consolidated'],
+        original_memory_ids: [block1.id, block2.id],
+      },
+    });
+    expect(seed1Res.status(), `seed 1 failed: ${await seed1Res.text()}`).toBe(201);
+    const seed1 = await seed1Res.json();
+
+    const suggestion2ToReject = `Reject-${runId}`;
+    const seed2Res = await request.post(`${BACKEND}/test-fixtures/consolidation-suggestion`, {
+      headers: { ...headers, 'content-type': 'application/json' },
+      data: {
+        suggested_content: `${suggestion2ToReject}: merged content (will be rejected)`,
+        suggested_lessons_learned: 'Rejected suggestion lesson',
+        suggested_keywords: ['rejected', 'discarded'],
+        original_memory_ids: [block1.id, block2.id],
+      },
+    });
+    expect(seed2Res.status()).toBe(201);
+    const seed2 = await seed2Res.json();
+
+    // ── 3. Navigate to consolidation suggestions UI ──────────────────────────
+    await asUser(page, email);
+    // Auto-accept the alert() that handleValidate / handleReject pop up.
+    page.on('dialog', (d) => {
+      void d.accept();
+    });
+
+    await page.goto('/consolidation-suggestions');
+
+    // Both suggestions should be visible.
+    await expect(page.getByText(suggestion1ToValidate, { exact: false })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(suggestion2ToReject, { exact: false })).toBeVisible({ timeout: 5_000 });
+
+    // ── 4. Validate the first suggestion via UI ──────────────────────────────
+    const card1 = page.locator('article,div,li,tr').filter({ hasText: suggestion1ToValidate }).first();
+    await card1.getByRole('button', { name: /^accept$/i }).click();
+
+    // ── 5. Reject the second suggestion ──────────────────────────────────────
+    const card2 = page.locator('article,div,li,tr').filter({ hasText: suggestion2ToReject }).first();
+    await card2.getByRole('button', { name: /^reject$/i }).click();
+
+    // ── 6. Verify status flips via API ───────────────────────────────────────
+    await page.waitForTimeout(500);
+    const listRes = await request.get(`${BACKEND}/consolidation-suggestions/`, { headers });
+    const data = await listRes.json();
+    const items: Array<{ suggestion_id: string; status: string }> = data.items || data;
+    const after1 = items.find((s) => s.suggestion_id === seed1.suggestion_id);
+    const after2 = items.find((s) => s.suggestion_id === seed2.suggestion_id);
+    expect(after1?.status?.toLowerCase()).toBe('validated');
+    expect(after2?.status?.toLowerCase()).toBe('rejected');
+
+    // ── 7. Cleanup ────────────────────────────────────────────────────────────
+    await request.delete(`${BACKEND}/consolidation-suggestions/${seed1.suggestion_id}`, { headers });
+    await request.delete(`${BACKEND}/consolidation-suggestions/${seed2.suggestion_id}`, { headers });
+    await request.delete(`${BACKEND}/agents/${agent.agent_id}`, { headers });
+  });
+});

--- a/apps/hindsight-service/core/api/main.py
+++ b/apps/hindsight-service/core/api/main.py
@@ -162,6 +162,17 @@ app.include_router(compression_router)
 app.include_router(search_router)
 app.include_router(memory_blocks_bulk_router)
 
+# Test-fixtures router — ONLY mounted when E2E_TEST_HOOKS=true.
+# These endpoints seed DB state for the Playwright E2E suite and bypass
+# LLM-gated paths (e.g. consolidation suggestion creation). MUST NOT be
+# enabled in production. See `core/api/test_fixtures.py` for the security
+# model. The conditional import means the routes literally do not exist in
+# prod bytecode when the flag is unset.
+if os.getenv("E2E_TEST_HOOKS", "false").lower() == "true":
+    from core.api.test_fixtures import router as test_fixtures_router  # noqa: E402
+    app.include_router(test_fixtures_router)
+    logger.warning("E2E_TEST_HOOKS=true — test-fixtures endpoints mounted. NEVER enable in production.")
+
 # Include memory optimization router
 try:
     from core.api.memory_optimization import router as memory_optimization_router

--- a/apps/hindsight-service/core/api/test_fixtures.py
+++ b/apps/hindsight-service/core/api/test_fixtures.py
@@ -1,0 +1,118 @@
+"""Test-fixtures endpoints — gated behind E2E_TEST_HOOKS=true.
+
+These endpoints exist solely to seed DB state for the Playwright E2E
+suite (umbrella #96). They bypass production code paths that require
+LLM (e.g. consolidation suggestion generation), letting tests exercise
+the UI flows that operate on the resulting rows.
+
+## Security model — three layers of defense
+
+1. **Module not imported when flag is off.** ``core/api/main.py``
+   conditionally imports + mounts this router only when
+   ``E2E_TEST_HOOKS=true``. In production deploys, the env var is unset
+   and the routes literally do not exist (404).
+2. **In-handler re-check.** Every handler starts with
+   ``_assert_hooks_enabled()``. Defense-in-depth — even if someone
+   accidentally mounts the router unconditionally.
+3. **CI-only env var.** ``E2E_TEST_HOOKS=true`` lives in
+   ``.github/workflows/e2e.yml`` only; production compose files,
+   helm values, etc. never set it.
+
+## Authorization
+
+Endpoints still require oauth2-proxy headers (e.g.
+``x-auth-request-email``). The header identity is the OWNER of the
+seeded data — protects against a leaked endpoint being used to read
+other users' data via the response serializer.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from core.api.deps import UserContext, get_current_user_context
+from core.db import models, schemas
+from core.db.database import get_db
+from core.db.repositories import consolidation_suggestions as cs_repo
+
+router = APIRouter(prefix="/test-fixtures", tags=["test-fixtures"])
+
+
+def _hooks_enabled() -> bool:
+    return os.getenv("E2E_TEST_HOOKS", "false").lower() == "true"
+
+
+def _assert_hooks_enabled() -> None:
+    """Raise 404 (not 403) when the flag is off — the route should
+    appear not to exist at all to outside callers."""
+    if not _hooks_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+
+class SeedConsolidationSuggestionRequest(BaseModel):
+    """Payload for seeding a ConsolidationSuggestion row.
+
+    All fields below are persisted directly. ``original_memory_ids`` is
+    enforced to be a list of memory blocks owned by the requesting user
+    (defense against the leaked-endpoint scenario).
+    """
+
+    suggested_content: str
+    suggested_lessons_learned: str = ""
+    suggested_keywords: List[str] = []
+    original_memory_ids: List[str]
+    group_id: Optional[uuid.UUID] = None
+    status: str = "pending"
+
+
+@router.post("/consolidation-suggestion", status_code=status.HTTP_201_CREATED)
+def seed_consolidation_suggestion(
+    payload: SeedConsolidationSuggestionRequest,
+    db: Session = Depends(get_db),
+    user_context: UserContext = Depends(get_current_user_context),
+):
+    """Seed a ConsolidationSuggestion row owned by the requesting user.
+
+    Used by E2E journey #106 to test the validate / reject UI without
+    needing the LLM-driven consolidation worker (which is gated by
+    ``LLM_FEATURES_ENABLED``).
+
+    Validates ownership of all referenced memory blocks before insert.
+    """
+    _assert_hooks_enabled()
+    user = user_context.user
+
+    # Validate ownership of all referenced memory blocks
+    for mid in payload.original_memory_ids:
+        try:
+            mid_uuid = uuid.UUID(mid)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail=f"Invalid memory_id: {mid}")
+        block = db.query(models.MemoryBlock).filter(models.MemoryBlock.id == mid_uuid).first()
+        if not block:
+            raise HTTPException(status_code=404, detail=f"Memory block not found: {mid}")
+        if block.owner_user_id != user.id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Memory block {mid} not owned by requesting user",
+            )
+
+    suggestion_in = schemas.ConsolidationSuggestionCreate(
+        group_id=payload.group_id or uuid.uuid4(),
+        suggested_content=payload.suggested_content,
+        suggested_lessons_learned=payload.suggested_lessons_learned,
+        suggested_keywords=payload.suggested_keywords,
+        original_memory_ids=payload.original_memory_ids,
+        status=payload.status,
+    )
+    suggestion = cs_repo.create_consolidation_suggestion(db, suggestion=suggestion_in)
+    return {
+        "suggestion_id": str(suggestion.suggestion_id),
+        "group_id": str(suggestion.group_id),
+        "status": suggestion.status,
+    }

--- a/apps/hindsight-service/tests/integration/test_fixtures/test_e2e_hooks_gate.py
+++ b/apps/hindsight-service/tests/integration/test_fixtures/test_e2e_hooks_gate.py
@@ -1,0 +1,146 @@
+"""Gate tests for the E2E test-fixtures endpoints.
+
+Verifies the security model documented in `core/api/test_fixtures.py`:
+- When ``E2E_TEST_HOOKS`` env var is unset / false, every endpoint
+  returns **404** (route appears not to exist).
+- When set to "true", endpoints function normally.
+
+These tests pin the gate behavior so a future refactor that accidentally
+removes the `_assert_hooks_enabled()` check will fail loudly.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.db import models
+
+
+def _seed_user_and_block(db_session) -> tuple[models.User, models.MemoryBlock]:
+    user = models.User(
+        email=f"hooks-gate-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Hooks Gate User",
+        beta_access_status="accepted",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    agent = models.Agent(
+        agent_name=f"hooks-gate-agent-{uuid.uuid4().hex[:6]}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+
+    block = models.MemoryBlock(
+        agent_id=agent.agent_id,
+        conversation_id=uuid.uuid4(),
+        content="hooks gate test content",
+        lessons_learned="hooks gate test lessons",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(block)
+    db_session.commit()
+    db_session.refresh(block)
+    return user, block
+
+
+def _payload(block_id: uuid.UUID) -> dict:
+    return {
+        "suggested_content": "merged content",
+        "suggested_lessons_learned": "merged lessons",
+        "suggested_keywords": ["test"],
+        "original_memory_ids": [str(block_id)],
+    }
+
+
+def _headers(user: models.User) -> dict:
+    return {
+        "x-auth-request-email": user.email,
+        "x-auth-request-user": user.email,
+    }
+
+
+def test_seed_endpoint_returns_404_when_hooks_flag_unset(monkeypatch, db_session):
+    """Default behavior: env var unset means /test-fixtures/* routes don't exist."""
+    monkeypatch.delenv("E2E_TEST_HOOKS", raising=False)
+
+    # The router is conditionally mounted in main.py at app construction
+    # time; importing it would mount it. Bypass by directly invoking the
+    # handler module's gate behavior — the in-handler check is the
+    # defense-in-depth that we test here.
+    from core.api import test_fixtures as tf
+
+    assert tf._hooks_enabled() is False
+    with pytest.raises(Exception) as exc_info:
+        tf._assert_hooks_enabled()
+    # FastAPI HTTPException raises with status_code 404
+    assert getattr(exc_info.value, "status_code", None) == 404
+
+
+def test_seed_endpoint_returns_404_when_hooks_flag_false(monkeypatch):
+    """Explicit false also disables the routes."""
+    monkeypatch.setenv("E2E_TEST_HOOKS", "false")
+    from core.api import test_fixtures as tf
+
+    assert tf._hooks_enabled() is False
+
+
+def test_seed_endpoint_works_when_hooks_flag_true(monkeypatch, db_session):
+    """With the flag set, the handler creates the suggestion row."""
+    monkeypatch.setenv("E2E_TEST_HOOKS", "true")
+    from core.api import test_fixtures as tf
+    from core.api.main import app
+
+    # The router is conditionally mounted at app startup. For this in-process
+    # test we mount it explicitly to verify handler behavior.
+    if not any(getattr(r, "path", "").startswith("/test-fixtures") for r in app.routes):
+        app.include_router(tf.router)
+
+    user, block = _seed_user_and_block(db_session)
+    client = TestClient(app)
+    resp = client.post(
+        "/test-fixtures/consolidation-suggestion",
+        json=_payload(block.id),
+        headers=_headers(user),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "suggestion_id" in body
+    assert body["status"] == "pending"
+
+
+def test_seed_endpoint_rejects_block_owned_by_another_user(monkeypatch, db_session):
+    """Defense against leaked-endpoint scenario: user can't seed against blocks they don't own."""
+    monkeypatch.setenv("E2E_TEST_HOOKS", "true")
+    from core.api import test_fixtures as tf
+    from core.api.main import app
+
+    if not any(getattr(r, "path", "").startswith("/test-fixtures") for r in app.routes):
+        app.include_router(tf.router)
+
+    owner, block = _seed_user_and_block(db_session)
+    other_user = models.User(
+        email=f"other-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Other User",
+        beta_access_status="accepted",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+
+    client = TestClient(app)
+    # `other_user` tries to seed a suggestion using `owner`'s block
+    resp = client.post(
+        "/test-fixtures/consolidation-suggestion",
+        json=_payload(block.id),
+        headers=_headers(other_user),
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not owned" in resp.text


### PR DESCRIPTION
Closes #106. Stacked on #112.

## Backend
- New gated /test-fixtures/consolidation-suggestion endpoint (3 layers of defense, in-prod = 404)
- 4 backend tests verify the gate

## Frontend
- Journey 5 seeds via the test-fixture, exercises the validate/reject UI

## Why pruning (#108) isn't included
Pruning is ad-hoc LLM computation, not stored rows. Needs different unblocking (mock LLM provider) — separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)