### PR TITLE
fix(backend): cascade-delete feedback_logs when agent/memory_block is removed (#127)

### DIFF
--- a/apps/hindsight-service/core/db/models/memory.py
+++ b/apps/hindsight-service/core/db/models/memory.py
@@ -53,7 +53,7 @@ class MemoryBlock(Base):
 class FeedbackLog(Base):
     __tablename__ = 'feedback_logs'
     feedback_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id'), nullable=False)
+    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id', ondelete='CASCADE'), nullable=False)
     feedback_type = Column(String(50), nullable=False)
     feedback_details = Column(Text)
     created_at = Column(DateTime(timezone=True), default=now_utc)

--- a/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
+++ b/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade feedback logs when memory blocks are deleted
+
+Revision ID: 2026050200
+Revises: 2026042900
+Create Date: 2026-05-02 02:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026050200"
+down_revision: Union[str, None] = "2026042900"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+    )

--- a/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
+++ b/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
@@ -1,0 +1,58 @@
+import uuid
+
+from sqlalchemy.orm import Session
+
+from core.db import models
+
+
+def _headers(email: str) -> dict[str, str]:
+    return {
+        "X-Auth-Request-User": email.split("@")[0],
+        "X-Auth-Request-Email": email,
+        "X-Active-Scope": "personal",
+    }
+
+
+def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_session: Session):
+    email = f"cascade_{uuid.uuid4().hex}@example.com"
+    user = models.User(email=email, display_name="Cascade Owner")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    agent = models.Agent(
+        agent_name=f"Cascade Agent {uuid.uuid4().hex}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+
+    memory_block = models.MemoryBlock(
+        agent_id=agent.agent_id,
+        conversation_id=uuid.uuid4(),
+        content="memory with feedback",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(memory_block)
+    db_session.flush()
+
+    db_session.add(
+        models.FeedbackLog(
+            memory_id=memory_block.id,
+            feedback_type="positive",
+            feedback_details="kept until the parent memory is deleted",
+        )
+    )
+    db_session.commit()
+    agent_id = agent.agent_id
+    memory_id = memory_block.id
+
+    response = client.delete(f"/agents/{agent_id}", headers=_headers(email))
+
+    assert response.status_code == 204, response.text
+    assert db_session.query(models.Agent).filter_by(agent_id=agent_id).count() == 0
+    assert db_session.query(models.MemoryBlock).filter_by(id=memory_id).count() == 0
+    assert db_session.query(models.FeedbackLog).filter_by(memory_id=memory_id).count() == 0


### PR DESCRIPTION
## Summary

Fixes the backend FK cascade gap from issue #127 by making `feedback_logs.memory_id` cascade when its parent `memory_blocks.id` row is deleted.

## Failing trace

> DELETE /agents/<id> -> 500 `(psycopg2.errors.ForeignKeyViolation) update or delete on table "memory_blocks" violates foreign key constraint "feedback_logs_memory_id_fkey" on table "feedback_logs"`

## Root cause

The agent delete path bulk-deletes `memory_blocks` rows by `agent_id`. Bulk deletes bypass SQLAlchemy relationship cascades, and the database FK from `feedback_logs.memory_id` to `memory_blocks.id` did not have `ON DELETE CASCADE`, so existing feedback rows blocked memory deletion.

## Fix

Chose a DB-level `ON DELETE CASCADE` fix because it protects every delete path, including the current bulk delete and any future raw SQL or repository-level memory deletion. The SQLAlchemy model now declares the cascade, and the Alembic migration recreates only `feedback_logs_memory_id_fkey` with `ondelete="CASCADE"`.

## Test

Added `tests/integration/agents/test_agent_delete_cascade.py`, which creates an agent -> memory_block -> feedback_log chain, calls `DELETE /agents/<id>`, and asserts the agent, memory block, and feedback log rows are gone.

## Verification

- Reproducer failed before the fix with the same `feedback_logs_memory_id_fkey` violation.
- `uv run pytest -x` -> 889 passed, 8 skipped, coverage 80.81%.
- Fresh pgvector Postgres: `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:65052/hindsight_db uv run alembic upgrade head` passed.

Refs #127
