### PR TITLE
fix(backend): cascade-delete memory_block_keywords on memory delete (#129)

### DIFF
--- a/apps/hindsight-service/core/db/models/memory.py
+++ b/apps/hindsight-service/core/db/models/memory.py
@@ -53,7 +53,7 @@ class MemoryBlock(Base):
 class FeedbackLog(Base):
     __tablename__ = 'feedback_logs'
     feedback_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id'), nullable=False)
+    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id', ondelete='CASCADE'), nullable=False)
     feedback_type = Column(String(50), nullable=False)
     feedback_details = Column(Text)
     created_at = Column(DateTime(timezone=True), default=now_utc)

--- a/apps/hindsight-service/core/db/models/memory.py
+++ b/apps/hindsight-service/core/db/models/memory.py
@@ -63,7 +63,7 @@ class FeedbackLog(Base):
 
 class MemoryBlockKeyword(Base):
     __tablename__ = 'memory_block_keywords'
-    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id'), primary_key=True)
+    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id', ondelete='CASCADE'), primary_key=True)
     keyword_id = Column(UUID(as_uuid=True), ForeignKey('keywords.keyword_id'), primary_key=True)
 
     memory_block = relationship("MemoryBlock", back_populates="memory_block_keywords")

--- a/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
+++ b/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade feedback logs when memory blocks are deleted
+
+Revision ID: 2026050200
+Revises: 2026042900
+Create Date: 2026-05-02 02:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026050200"
+down_revision: Union[str, None] = "2026042900"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+    )

--- a/apps/hindsight-service/migrations/versions/2026050201_memory_block_keywords_memory_cascade.py
+++ b/apps/hindsight-service/migrations/versions/2026050201_memory_block_keywords_memory_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade memory block keywords when memory blocks are deleted
+
+Revision ID: 2026050201
+Revises: 2026050200
+Create Date: 2026-05-02 02:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026050201"
+down_revision: Union[str, None] = "2026050200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("memory_block_keywords_memory_id_fkey", "memory_block_keywords", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_block_keywords_memory_id_fkey",
+        "memory_block_keywords",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("memory_block_keywords_memory_id_fkey", "memory_block_keywords", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_block_keywords_memory_id_fkey",
+        "memory_block_keywords",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+    )

--- a/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
+++ b/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
@@ -1,0 +1,58 @@
+import uuid
+
+from sqlalchemy.orm import Session
+
+from core.db import models
+
+
+def _headers(email: str) -> dict[str, str]:
+    return {
+        "X-Auth-Request-User": email.split("@")[0],
+        "X-Auth-Request-Email": email,
+        "X-Active-Scope": "personal",
+    }
+
+
+def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_session: Session):
+    email = f"cascade_{uuid.uuid4().hex}@example.com"
+    user = models.User(email=email, display_name="Cascade Owner")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    agent = models.Agent(
+        agent_name=f"Cascade Agent {uuid.uuid4().hex}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+
+    memory_block = models.MemoryBlock(
+        agent_id=agent.agent_id,
+        conversation_id=uuid.uuid4(),
+        content="memory with feedback",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(memory_block)
+    db_session.flush()
+
+    db_session.add(
+        models.FeedbackLog(
+            memory_id=memory_block.id,
+            feedback_type="positive",
+            feedback_details="kept until the parent memory is deleted",
+        )
+    )
+    db_session.commit()
+    agent_id = agent.agent_id
+    memory_id = memory_block.id
+
+    response = client.delete(f"/agents/{agent_id}", headers=_headers(email))
+
+    assert response.status_code == 204, response.text
+    assert db_session.query(models.Agent).filter_by(agent_id=agent_id).count() == 0
+    assert db_session.query(models.MemoryBlock).filter_by(id=memory_id).count() == 0
+    assert db_session.query(models.FeedbackLog).filter_by(memory_id=memory_id).count() == 0

--- a/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
+++ b/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
@@ -13,7 +13,7 @@ def _headers(email: str) -> dict[str, str]:
     }
 
 
-def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_session: Session):
+def test_delete_agent_cascades_dependent_rows_for_memory_blocks(client, db_session: Session):
     email = f"cascade_{uuid.uuid4().hex}@example.com"
     user = models.User(email=email, display_name="Cascade Owner")
     db_session.add(user)
@@ -46,9 +46,23 @@ def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_sessio
             feedback_details="kept until the parent memory is deleted",
         )
     )
+    keyword = models.Keyword(
+        keyword_text=f"cascade-keyword-{uuid.uuid4().hex}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(keyword)
+    db_session.flush()
+    db_session.add(
+        models.MemoryBlockKeyword(
+            memory_id=memory_block.id,
+            keyword_id=keyword.keyword_id,
+        )
+    )
     db_session.commit()
     agent_id = agent.agent_id
     memory_id = memory_block.id
+    keyword_id = keyword.keyword_id
 
     response = client.delete(f"/agents/{agent_id}", headers=_headers(email))
 
@@ -56,3 +70,5 @@ def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_sessio
     assert db_session.query(models.Agent).filter_by(agent_id=agent_id).count() == 0
     assert db_session.query(models.MemoryBlock).filter_by(id=memory_id).count() == 0
     assert db_session.query(models.FeedbackLog).filter_by(memory_id=memory_id).count() == 0
+    assert db_session.query(models.MemoryBlockKeyword).filter_by(memory_id=memory_id).count() == 0
+    assert db_session.query(models.Keyword).filter_by(keyword_id=keyword_id).count() == 1


### PR DESCRIPTION
## Summary

This PR includes #128's commit (76f35d0); the diff will collapse to a single commit once #128 merges.

Fixes the sibling cascade gap where `delete_agent` bulk-deletes `memory_blocks`, bypassing SQLAlchemy ORM `cascade='all, delete-orphan'`, while `memory_block_keywords.memory_id` still had a non-cascading database foreign key. This mirrors #128 by moving the cascade guarantee to the database layer with `ON DELETE CASCADE` and a chained Alembic migration.

## Verification

- Regression check: with the new migration/model cascade temporarily removed, the focused test failed with `psycopg2.errors.ForeignKeyViolation` on `memory_block_keywords_memory_id_fkey`.
- `uv run pytest -x` -> `889 passed, 8 skipped, 21 warnings in 107.59s (0:01:47)`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5433/hindsight_db uv run alembic upgrade head` -> ran `2026042900 -> 2026050200` and `2026050200 -> 2026050201`.

Closes #129