### PR TITLE
fix(e2e): @full-tier selector + timing fixes for J5/J7/J9/J13 + J3a strict-mode (#127)

### DIFF
--- a/apps/hindsight-dashboard/e2e/journeys/03a-search-fulltext.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/03a-search-fulltext.spec.ts
@@ -41,8 +41,11 @@ test.describe('Journey 3a — Memory block fulltext search @smoke', () => {
     await searchInput.press('Enter');
 
     // The block whose `marker` is `python-fastapi` should appear in the rendered list.
-    // Card content includes the lessons string: "python pattern: use python-fastapi for ..."
-    await expect(page.getByText('python-fastapi', { exact: false })).toBeVisible({
+    // The card renders BOTH `content` and `lessons_learned` — and both contain the
+    // substring "python-fastapi" (see fixtures/referenceDataset.ts buildReferenceBlocks),
+    // so a non-anchored `getByText` match resolves to 2+ elements and trips
+    // strict-mode. Use `.first()` — same pattern as line below + journey 8 fix (#116).
+    await expect(page.getByText('python-fastapi', { exact: false }).first()).toBeVisible({
       timeout: 15_000,
     });
 

--- a/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
@@ -97,11 +97,15 @@ test.describe('Journey 5 — Consolidation validate / reject @full', () => {
     await expect(page.getByText(suggestion2ToReject, { exact: false })).toBeVisible({ timeout: 5_000 });
 
     // ── 4. Validate the first suggestion via UI ──────────────────────────────
-    const card1 = page.locator('article,div,li,tr').filter({ hasText: suggestion1ToValidate }).first();
+    const card1 = page
+      .getByText(suggestion1ToValidate, { exact: false })
+      .locator('xpath=ancestor::div[.//button[normalize-space()="Accept"]][1]');
     await card1.getByRole('button', { name: /^accept$/i }).click();
 
     // ── 5. Reject the second suggestion ──────────────────────────────────────
-    const card2 = page.locator('article,div,li,tr').filter({ hasText: suggestion2ToReject }).first();
+    const card2 = page
+      .getByText(suggestion2ToReject, { exact: false })
+      .locator('xpath=ancestor::div[.//button[normalize-space()="Reject"]][1]');
     await card2.getByRole('button', { name: /^reject$/i }).click();
 
     // ── 6. Verify status flips via API ───────────────────────────────────────

--- a/apps/hindsight-dashboard/e2e/journeys/07-pruning.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/07-pruning.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { asUser } from '../helpers/auth';
-import { autoAcceptConfirm, expectConfirm } from '../helpers/dialogs';
+import { expectConfirm } from '../helpers/dialogs';
 import { provisionUser } from '../helpers/provision';
 import { temail, tname, runId } from '../helpers/runId';
 
@@ -23,10 +23,39 @@ const BACKEND = 'http://localhost:8000';
 
 test.describe('Journey 7 — Pruning @full', () => {
   test('generate suggestions, confirm pruning, verify archive', async ({ page, request }) => {
-    autoAcceptConfirm(page);
     const email = temail('prune-user');
     await provisionUser(page, email);
     const headers = { 'x-auth-request-email': email, 'x-auth-request-user': email, 'x-active-scope': 'personal' };
+
+    // The backend's E2E_TEST_HOOKS bypass lets pruning use deterministic
+    // fallback scoring while the global LLM flag is false. Keep the browser
+    // feature gate open so the UI can exercise that endpoint path.
+    await page.addInitScript(() => {
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const response = await originalFetch(input, init);
+        const requestUrl =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input instanceof Request
+                ? input.url
+                : '';
+        if (!requestUrl.includes('/user-info')) return response;
+
+        const body = await response.clone().json().catch(() => null);
+        if (!body || typeof body !== 'object') return response;
+
+        const headers = new Headers(response.headers);
+        headers.set('content-type', 'application/json');
+        return new Response(JSON.stringify({ ...body, llm_features_enabled: true }), {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      };
+    });
 
     // ── 1. Seed: agent + several memory blocks (need enough for the heuristic
     //         to score them) ──────────────────────────────────────────────────
@@ -67,19 +96,26 @@ test.describe('Journey 7 — Pruning @full', () => {
       timeout: 25_000,
     });
 
-    // ── 4. Select the first suggestion via its checkbox ───────────────────────
-    // The selection UI uses native checkboxes per row. Click the first one.
-    const firstCheckbox = page.locator('input[type="checkbox"]').first();
+    // ── 4. Select the first suggestion from our seeded agent via its checkbox ─
+    // The first checkbox in the table is "select all"; scope to a candidate row.
+    const firstCandidateRow = page.locator('tr').filter({ hasText: /Pruning candidate \d+ / }).first();
+    const firstCheckbox = firstCandidateRow.getByRole('checkbox');
     await firstCheckbox.check();
 
     // ── 5. Confirm Pruning — uses strict expectConfirm to defend against
     //         "confirm popup got bypassed" regressions ──────────────────────────
+    const archiveButton = page.getByRole('button', { name: /archive selected \(1\)/i });
+    await expect(archiveButton).toBeEnabled();
     const dialog = expectConfirm(
       page,
       /Are you sure you want to archive .* memory blocks for pruning/i,
     );
-    await page.getByRole('button', { name: /confirm pruning/i }).click();
+    const successDialog = page
+      .waitForEvent('dialog', (d) => d.type() === 'alert' && /Successfully archived/i.test(d.message()))
+      .then((d) => d.accept());
+    await archiveButton.click();
     await dialog;
+    await successDialog;
 
     // ── 6. Verify at least one block was archived via API ─────────────────────
     // Wait briefly for the backend to commit the archive.

--- a/apps/hindsight-dashboard/e2e/journeys/09-org-invitations.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/09-org-invitations.spec.ts
@@ -96,6 +96,7 @@ test.describe('Journey 9 — Org invitations + accept flow @full', () => {
     // ── 7. Verify revoked invitation reflects status ──────────────────────────
     const afterRes = await request.get(`${BACKEND}/organizations/${org.id}/invitations`, {
       headers: ownerHeaders,
+      params: { status: 'all' },
     });
     const afterData = await afterRes.json();
     const afterItems: Array<{ id: string; status: string }> = afterData.items || afterData;

--- a/apps/hindsight-dashboard/e2e/journeys/13-compaction-trigger.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/13-compaction-trigger.spec.ts
@@ -66,6 +66,7 @@ test.describe('Journey 13 — Compaction trigger (LLM-disabled path) @full', () 
     // (per MemoryBlockCard.tsx around line 95).
     const compactBtn = page.getByTitle(/Compact Memory/i).first();
     await expect(compactBtn).toBeVisible({ timeout: 10_000 });
+    await expect(compactBtn).toBeEnabled();
 
     // Track if the modal opens — it shouldn't, because LLM is disabled in CI.
     // The modal heading should never appear on screen.

--- a/apps/hindsight-dashboard/src/components/MemoryBlockCard.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockCard.tsx
@@ -93,7 +93,6 @@ const MemoryBlockCard: React.FC<MemoryBlockCardProps> = ({ memoryBlock, onClick,
             onClick={(e) => handleCompactClick(e)}
             className="p-2 hover:bg-green-100 rounded-md transition-colors text-gray-400 hover:text-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
             title="Compact Memory - Intelligently condense content"
-            disabled={!llmEnabled}
           >
             <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />


### PR DESCRIPTION
## Summary

Closes the **frontend half of #127**. Backend halves (`feedback_logs` and `memory_block_keywords` cascades) already landed as #128 and #130.

The four `@full`-tier journey failures we saw on staging push are now green; J3a's pre-existing strict-mode flake on \`python-fastapi\` (caught while running smoke regression) is also fixed.

## Per-journey root cause

| Journey | Root cause | Fix |
|---|---|---|
| **J5 consolidation** | \`locator('article,div,li,tr').filter(...)\` matched a wrapper card; \`.first()\` resolved to the wrong Accept button. | Tightened to scope to the actionable suggestion card. Same shape as #116 (J8). |
| **J7 pruning** | Confirm-pruning button stayed disabled because the E2E LLM gate override wasn't reaching the page. | Routed override through the existing \`/user-info\` LLM flag; tightened row-scoped checkbox + \`Archive Selected (1)\` button + strict confirm/success dialogs. |
| **J9 org invitations** | Final-state assertion after the second-revoke read the default \`pending\` invitation list, missing the revoked entry. | Query \`?status=all\` instead. |
| **J13 compaction trigger** | The Compact button was \`disabled={!llmEnabled}\`, so the LLM-disabled toast handler was unreachable (the click never fired). | Removed the \`disabled\` prop in \`MemoryBlockCard.tsx\`. **Real prod UX improvement** — users now get an explanatory toast instead of a silently-dead button. |
| **J3a smoke regression** (caught during verification) | \`getByText('python-fastapi', { exact: false }).toBeVisible()\` matched 2 elements: the seeded block has the substring in BOTH \`content\` AND \`lessons_learned\`, both rendered on the card. | Added \`.first()\` — same pattern as the existing assertion 9 lines below in the same test. |

## Verification

Reproduced both failure modes against the e2e DB (port 5433, container \`hindsight-e2e-pg\`), then re-ran post-fix:

\`\`\`
bunx playwright test --grep @smoke --workers=1
  → 13/13 pass

bunx playwright test e2e/journeys/05-consolidation.spec.ts e2e/journeys/07-pruning.spec.ts \\
                    e2e/journeys/09-org-invitations.spec.ts e2e/journeys/13-compaction-trigger.spec.ts \\
                    --workers=1
  → 4/4 pass
\`\`\`

## Test plan

- [x] All four target \`@full\` journeys pass locally
- [x] Smoke suite (13 tests) passes locally — including J3a after the strict-mode fix
- [x] J13's removal of \`disabled\` doesn't regress the LLM-enabled path (the existing handler short-circuits when \`llmEnabled\`)
- [ ] CI \`E2E smoke\` passes on this PR
- [ ] After merge, staging \`E2E full\` job goes green for the first time since umbrella #96 shipped

## Provenance

Initial drafting and per-journey diagnosis was done by a Looper-driven \`codex-cli\` agent (task ced91039) running on a dedicated worktree. The agent halted on the J3a smoke regression and surfaced it; I diagnosed (seeded data has duplicate substring matches), added the \`.first()\` fix mirroring the existing pattern in the file, and verified end-to-end before push.

Refs #127 (umbrella).