### PR TITLE
Staging → main: backend cascade fixes (#128, #130) + frontend @full-tier fixes (#131)

### DIFF
--- a/apps/hindsight-dashboard/e2e/journeys/03a-search-fulltext.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/03a-search-fulltext.spec.ts
@@ -41,8 +41,11 @@ test.describe('Journey 3a — Memory block fulltext search @smoke', () => {
     await searchInput.press('Enter');
 
     // The block whose `marker` is `python-fastapi` should appear in the rendered list.
-    // Card content includes the lessons string: "python pattern: use python-fastapi for ..."
-    await expect(page.getByText('python-fastapi', { exact: false })).toBeVisible({
+    // The card renders BOTH `content` and `lessons_learned` — and both contain the
+    // substring "python-fastapi" (see fixtures/referenceDataset.ts buildReferenceBlocks),
+    // so a non-anchored `getByText` match resolves to 2+ elements and trips
+    // strict-mode. Use `.first()` — same pattern as line below + journey 8 fix (#116).
+    await expect(page.getByText('python-fastapi', { exact: false }).first()).toBeVisible({
       timeout: 15_000,
     });
 

--- a/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/05-consolidation.spec.ts
@@ -97,11 +97,15 @@ test.describe('Journey 5 — Consolidation validate / reject @full', () => {
     await expect(page.getByText(suggestion2ToReject, { exact: false })).toBeVisible({ timeout: 5_000 });
 
     // ── 4. Validate the first suggestion via UI ──────────────────────────────
-    const card1 = page.locator('article,div,li,tr').filter({ hasText: suggestion1ToValidate }).first();
+    const card1 = page
+      .getByText(suggestion1ToValidate, { exact: false })
+      .locator('xpath=ancestor::div[.//button[normalize-space()="Accept"]][1]');
     await card1.getByRole('button', { name: /^accept$/i }).click();
 
     // ── 5. Reject the second suggestion ──────────────────────────────────────
-    const card2 = page.locator('article,div,li,tr').filter({ hasText: suggestion2ToReject }).first();
+    const card2 = page
+      .getByText(suggestion2ToReject, { exact: false })
+      .locator('xpath=ancestor::div[.//button[normalize-space()="Reject"]][1]');
     await card2.getByRole('button', { name: /^reject$/i }).click();
 
     // ── 6. Verify status flips via API ───────────────────────────────────────

--- a/apps/hindsight-dashboard/e2e/journeys/07-pruning.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/07-pruning.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { asUser } from '../helpers/auth';
-import { autoAcceptConfirm, expectConfirm } from '../helpers/dialogs';
+import { expectConfirm } from '../helpers/dialogs';
 import { provisionUser } from '../helpers/provision';
 import { temail, tname, runId } from '../helpers/runId';
 
@@ -23,10 +23,39 @@ const BACKEND = 'http://localhost:8000';
 
 test.describe('Journey 7 — Pruning @full', () => {
   test('generate suggestions, confirm pruning, verify archive', async ({ page, request }) => {
-    autoAcceptConfirm(page);
     const email = temail('prune-user');
     await provisionUser(page, email);
     const headers = { 'x-auth-request-email': email, 'x-auth-request-user': email, 'x-active-scope': 'personal' };
+
+    // The backend's E2E_TEST_HOOKS bypass lets pruning use deterministic
+    // fallback scoring while the global LLM flag is false. Keep the browser
+    // feature gate open so the UI can exercise that endpoint path.
+    await page.addInitScript(() => {
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const response = await originalFetch(input, init);
+        const requestUrl =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input instanceof Request
+                ? input.url
+                : '';
+        if (!requestUrl.includes('/user-info')) return response;
+
+        const body = await response.clone().json().catch(() => null);
+        if (!body || typeof body !== 'object') return response;
+
+        const headers = new Headers(response.headers);
+        headers.set('content-type', 'application/json');
+        return new Response(JSON.stringify({ ...body, llm_features_enabled: true }), {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      };
+    });
 
     // ── 1. Seed: agent + several memory blocks (need enough for the heuristic
     //         to score them) ──────────────────────────────────────────────────
@@ -67,19 +96,26 @@ test.describe('Journey 7 — Pruning @full', () => {
       timeout: 25_000,
     });
 
-    // ── 4. Select the first suggestion via its checkbox ───────────────────────
-    // The selection UI uses native checkboxes per row. Click the first one.
-    const firstCheckbox = page.locator('input[type="checkbox"]').first();
+    // ── 4. Select the first suggestion from our seeded agent via its checkbox ─
+    // The first checkbox in the table is "select all"; scope to a candidate row.
+    const firstCandidateRow = page.locator('tr').filter({ hasText: /Pruning candidate \d+ / }).first();
+    const firstCheckbox = firstCandidateRow.getByRole('checkbox');
     await firstCheckbox.check();
 
     // ── 5. Confirm Pruning — uses strict expectConfirm to defend against
     //         "confirm popup got bypassed" regressions ──────────────────────────
+    const archiveButton = page.getByRole('button', { name: /archive selected \(1\)/i });
+    await expect(archiveButton).toBeEnabled();
     const dialog = expectConfirm(
       page,
       /Are you sure you want to archive .* memory blocks for pruning/i,
     );
-    await page.getByRole('button', { name: /confirm pruning/i }).click();
+    const successDialog = page
+      .waitForEvent('dialog', (d) => d.type() === 'alert' && /Successfully archived/i.test(d.message()))
+      .then((d) => d.accept());
+    await archiveButton.click();
     await dialog;
+    await successDialog;
 
     // ── 6. Verify at least one block was archived via API ─────────────────────
     // Wait briefly for the backend to commit the archive.

--- a/apps/hindsight-dashboard/e2e/journeys/09-org-invitations.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/09-org-invitations.spec.ts
@@ -96,6 +96,7 @@ test.describe('Journey 9 — Org invitations + accept flow @full', () => {
     // ── 7. Verify revoked invitation reflects status ──────────────────────────
     const afterRes = await request.get(`${BACKEND}/organizations/${org.id}/invitations`, {
       headers: ownerHeaders,
+      params: { status: 'all' },
     });
     const afterData = await afterRes.json();
     const afterItems: Array<{ id: string; status: string }> = afterData.items || afterData;

--- a/apps/hindsight-dashboard/e2e/journeys/13-compaction-trigger.spec.ts
+++ b/apps/hindsight-dashboard/e2e/journeys/13-compaction-trigger.spec.ts
@@ -66,6 +66,7 @@ test.describe('Journey 13 — Compaction trigger (LLM-disabled path) @full', () 
     // (per MemoryBlockCard.tsx around line 95).
     const compactBtn = page.getByTitle(/Compact Memory/i).first();
     await expect(compactBtn).toBeVisible({ timeout: 10_000 });
+    await expect(compactBtn).toBeEnabled();
 
     // Track if the modal opens — it shouldn't, because LLM is disabled in CI.
     // The modal heading should never appear on screen.

--- a/apps/hindsight-dashboard/src/components/MemoryBlockCard.tsx
+++ b/apps/hindsight-dashboard/src/components/MemoryBlockCard.tsx
@@ -93,7 +93,6 @@ const MemoryBlockCard: React.FC<MemoryBlockCardProps> = ({ memoryBlock, onClick,
             onClick={(e) => handleCompactClick(e)}
             className="p-2 hover:bg-green-100 rounded-md transition-colors text-gray-400 hover:text-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
             title="Compact Memory - Intelligently condense content"
-            disabled={!llmEnabled}
           >
             <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/apps/hindsight-service/core/db/models/memory.py
+++ b/apps/hindsight-service/core/db/models/memory.py
@@ -53,7 +53,7 @@ class MemoryBlock(Base):
 class FeedbackLog(Base):
     __tablename__ = 'feedback_logs'
     feedback_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id'), nullable=False)
+    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id', ondelete='CASCADE'), nullable=False)
     feedback_type = Column(String(50), nullable=False)
     feedback_details = Column(Text)
     created_at = Column(DateTime(timezone=True), default=now_utc)

--- a/apps/hindsight-service/core/db/models/memory.py
+++ b/apps/hindsight-service/core/db/models/memory.py
@@ -63,7 +63,7 @@ class FeedbackLog(Base):
 
 class MemoryBlockKeyword(Base):
     __tablename__ = 'memory_block_keywords'
-    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id'), primary_key=True)
+    memory_id = Column(UUID(as_uuid=True), ForeignKey('memory_blocks.id', ondelete='CASCADE'), primary_key=True)
     keyword_id = Column(UUID(as_uuid=True), ForeignKey('keywords.keyword_id'), primary_key=True)
 
     memory_block = relationship("MemoryBlock", back_populates="memory_block_keywords")

--- a/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
+++ b/apps/hindsight-service/migrations/versions/2026050200_feedback_logs_memory_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade feedback logs when memory blocks are deleted
+
+Revision ID: 2026050200
+Revises: 2026042900
+Create Date: 2026-05-02 02:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026050200"
+down_revision: Union[str, None] = "2026042900"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("feedback_logs_memory_id_fkey", "feedback_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "feedback_logs_memory_id_fkey",
+        "feedback_logs",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+    )

--- a/apps/hindsight-service/migrations/versions/2026050201_memory_block_keywords_memory_cascade.py
+++ b/apps/hindsight-service/migrations/versions/2026050201_memory_block_keywords_memory_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade memory block keywords when memory blocks are deleted
+
+Revision ID: 2026050201
+Revises: 2026050200
+Create Date: 2026-05-02 02:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026050201"
+down_revision: Union[str, None] = "2026050200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("memory_block_keywords_memory_id_fkey", "memory_block_keywords", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_block_keywords_memory_id_fkey",
+        "memory_block_keywords",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("memory_block_keywords_memory_id_fkey", "memory_block_keywords", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_block_keywords_memory_id_fkey",
+        "memory_block_keywords",
+        "memory_blocks",
+        ["memory_id"],
+        ["id"],
+    )

--- a/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
+++ b/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
@@ -1,0 +1,58 @@
+import uuid
+
+from sqlalchemy.orm import Session
+
+from core.db import models
+
+
+def _headers(email: str) -> dict[str, str]:
+    return {
+        "X-Auth-Request-User": email.split("@")[0],
+        "X-Auth-Request-Email": email,
+        "X-Active-Scope": "personal",
+    }
+
+
+def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_session: Session):
+    email = f"cascade_{uuid.uuid4().hex}@example.com"
+    user = models.User(email=email, display_name="Cascade Owner")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    agent = models.Agent(
+        agent_name=f"Cascade Agent {uuid.uuid4().hex}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+
+    memory_block = models.MemoryBlock(
+        agent_id=agent.agent_id,
+        conversation_id=uuid.uuid4(),
+        content="memory with feedback",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(memory_block)
+    db_session.flush()
+
+    db_session.add(
+        models.FeedbackLog(
+            memory_id=memory_block.id,
+            feedback_type="positive",
+            feedback_details="kept until the parent memory is deleted",
+        )
+    )
+    db_session.commit()
+    agent_id = agent.agent_id
+    memory_id = memory_block.id
+
+    response = client.delete(f"/agents/{agent_id}", headers=_headers(email))
+
+    assert response.status_code == 204, response.text
+    assert db_session.query(models.Agent).filter_by(agent_id=agent_id).count() == 0
+    assert db_session.query(models.MemoryBlock).filter_by(id=memory_id).count() == 0
+    assert db_session.query(models.FeedbackLog).filter_by(memory_id=memory_id).count() == 0

--- a/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
+++ b/apps/hindsight-service/tests/integration/agents/test_agent_delete_cascade.py
@@ -13,7 +13,7 @@ def _headers(email: str) -> dict[str, str]:
     }
 
 
-def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_session: Session):
+def test_delete_agent_cascades_dependent_rows_for_memory_blocks(client, db_session: Session):
     email = f"cascade_{uuid.uuid4().hex}@example.com"
     user = models.User(email=email, display_name="Cascade Owner")
     db_session.add(user)
@@ -46,9 +46,23 @@ def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_sessio
             feedback_details="kept until the parent memory is deleted",
         )
     )
+    keyword = models.Keyword(
+        keyword_text=f"cascade-keyword-{uuid.uuid4().hex}",
+        visibility_scope="personal",
+        owner_user_id=user.id,
+    )
+    db_session.add(keyword)
+    db_session.flush()
+    db_session.add(
+        models.MemoryBlockKeyword(
+            memory_id=memory_block.id,
+            keyword_id=keyword.keyword_id,
+        )
+    )
     db_session.commit()
     agent_id = agent.agent_id
     memory_id = memory_block.id
+    keyword_id = keyword.keyword_id
 
     response = client.delete(f"/agents/{agent_id}", headers=_headers(email))
 
@@ -56,3 +70,5 @@ def test_delete_agent_cascades_feedback_logs_for_memory_blocks(client, db_sessio
     assert db_session.query(models.Agent).filter_by(agent_id=agent_id).count() == 0
     assert db_session.query(models.MemoryBlock).filter_by(id=memory_id).count() == 0
     assert db_session.query(models.FeedbackLog).filter_by(memory_id=memory_id).count() == 0
+    assert db_session.query(models.MemoryBlockKeyword).filter_by(memory_id=memory_id).count() == 0
+    assert db_session.query(models.Keyword).filter_by(keyword_id=keyword_id).count() == 1


### PR DESCRIPTION
## Summary

Three follow-ups to the umbrella that just shipped via PR #47 (foundation + 13 journeys + lockfile sync). All three landed on `staging` after #47 was merged:

- **#128** — `fix(backend): cascade-delete feedback_logs when agent/memory_block is removed`. Adds `ON DELETE CASCADE` to `feedback_logs.memory_id_fkey` (model + Alembic migration `2026050200`). Fixes a real prod bug: `DELETE /agents/<id>` was returning 500 when feedback rows existed for the agent's memory blocks.
- **#130** — `fix(backend): cascade-delete memory_block_keywords on memory delete` (originally filed as #129). Same cascade gap on the join table; mirror fix with migration `2026050201` chained off `2026050200`. Latent bug — bulk-delete from the same code path would have hit the same FK violation as soon as a test exercised the agent→memory_block→keyword chain.
- **#131** — `fix(e2e): @full-tier selector + timing fixes for J5/J7/J9/J13 + J3a strict-mode`. Frontend half of #127. One real prod UX improvement: J13's compact button no longer silently disabled when LLM is off — it now shows an explanatory toast.

## Verification

- Each PR was verified locally before merge (smoke + targeted journey runs all green).
- Most importantly: the **`E2E full` job on the post-#131 staging head ran completed/success** (run 25239454561) — first green of the @full job since the umbrella shipped.
- Staging deploy chain: `Dashboard (Jest) ✓ / pytest ✓ / build-and-push ✓ / deploy ✓`.

## Migrations

Two new Alembic migrations included (`2026050200` + `2026050201`). Both reversible (downgrade restores the non-cascading FK). Production DB will run them on deploy.

## Test plan

- [ ] CI `E2E smoke` passes on this PR
- [ ] After merge to main: production deploy runs cleanly (incl. Alembic upgrade)
- [ ] No regression in production behavior (cascade fixes are additive; frontend changes are E2E-spec-only except J13 UX)